### PR TITLE
change nextflow.config to correctly point to main script

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -1,5 +1,5 @@
 manifest {
-    mainScript = 'nCov.nf'
+    mainScript = 'poreCov.nf'
 }
 
 // default parameters


### PR DESCRIPTION
Currently, `nextflow.config` points to `nCov.nf` as the main script, so that `nextflow pull...` is not working. It should be `poreCov.nf` (or even better `main.nf`).