### PR TITLE
Dev replikation

### DIFF
--- a/bin/rki_report_parser.sh
+++ b/bin/rki_report_parser.sh
@@ -2,8 +2,9 @@
 #Info: Creates report.csv for RKI from all pangolin.csv-files in the actual working dir.
 
 SENDING_LAB_ID=$1
+OUTPUT_NAME=$2
 
-echo "IMS_ID,SENDING_LAB,DATE_DRAW,SEQ_TYPE,SEQ_REASON,SAMPLE_TYPE,OWN_FASTA_ID" > rki_report.csv
+echo "IMS_ID,SENDING_LAB,DATE_DRAW,SEQ_TYPE,SEQ_REASON,SAMPLE_TYPE,OWN_FASTA_ID" > $OUTPUT_NAME
 
 for FILENAME in lineage*.csv; do
     IMS_ID=$(echo "IMS-00000-CVDP-00000")
@@ -13,7 +14,7 @@ for FILENAME in lineage*.csv; do
     SEQU_REASON=$(echo "X")
     SAMPLE_TYPE=$(echo "X")
     OWN_FASTA_ID=$(tail -n+2 "$FILENAME" | rev | cut -f 6-10 -d "," | rev)
-    echo $IMS_ID","$SENDING_LAB","$DATE_DRAW","$SEQU_TYPE","$SEQU_REASON","$SAMPLE_TYPE","$OWN_FASTA_ID >> rki_report.csv
+    echo $IMS_ID","$SENDING_LAB","$DATE_DRAW","$SEQU_TYPE","$SEQU_REASON","$SAMPLE_TYPE","$OWN_FASTA_ID >> $OUTPUT_NAME
 done
 
 

--- a/bin/rki_report_parser.sh
+++ b/bin/rki_report_parser.sh
@@ -2,19 +2,20 @@
 #Info: Creates report.csv for RKI from all pangolin.csv-files in the actual working dir.
 
 SENDING_LAB_ID=$1
-OUTPUT_NAME=$2
+INPUT_NAME=$2
+OUTPUT_NAME=$3
 
 echo "IMS_ID,SENDING_LAB,DATE_DRAW,SEQ_TYPE,SEQ_REASON,SAMPLE_TYPE,OWN_FASTA_ID" > $OUTPUT_NAME
 
-for FILENAME in lineage*.csv; do
+while IFS=$'\t' read -r -a Array; do
     IMS_ID=$(echo "IMS-00000-CVDP-00000")
     SENDING_LAB=$(echo "$SENDING_LAB_ID")       #In Process export "SENDING_LAB_ID" (given as Input/default when using [--rki]).
     DATE_DRAW=$(echo "YYYYMMDD")
     SEQU_TYPE=$(echo "OXFORD_NANOPORE")
     SEQU_REASON=$(echo "X")
     SAMPLE_TYPE=$(echo "X")
-    OWN_FASTA_ID=$(tail -n+2 "$FILENAME" | rev | cut -f 6-10 -d "," | rev)
+    OWN_FASTA_ID="${Array[0]}"
     echo $IMS_ID","$SENDING_LAB","$DATE_DRAW","$SEQU_TYPE","$SEQU_REASON","$SAMPLE_TYPE","$OWN_FASTA_ID >> $OUTPUT_NAME
-done
+done < ${INPUT_NAME}
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -144,7 +144,7 @@ profiles {
             project = 'case-dev-302214'
             zone = 'europe-west1-b,europe-west1-c,europe-west2-b,europe-west2-a'
             lifeSciences.preemptible = true
-            lifeSciences.bootDiskSize = 20.GB
+            lifeSciences.bootDiskSize = 100.GB
             }
         includeConfig 'configs/container.config'
         includeConfig 'configs/nodes.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,7 +48,7 @@ params {
     output = 'results'
     cachedir = "singularity_images"
     databases = "references_nCov19"
-    readsdir = "0.Lineages"
+    readsdir = "0.Fastq_reads"
     readqcdir = "1.Read_quality"
     genomedir = "2.Genomes"
     lineagedir = "3.Lineages"

--- a/nextflow.config
+++ b/nextflow.config
@@ -144,7 +144,7 @@ profiles {
             project = 'case-dev-302214'
             zone = 'europe-west1-b,europe-west1-c,europe-west2-b,europe-west2-a'
             lifeSciences.preemptible = true
-            lifeSciences.bootDiskSize = 100.GB
+            lifeSciences.bootDiskSize = 20.GB
             }
         includeConfig 'configs/container.config'
         includeConfig 'configs/nodes.config'

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -185,14 +185,8 @@ workflow {
     // 2. Genome quality and lineages
         determine_lineage_wf(fasta_input_ch)
         genome_quality_wf(fasta_input_ch, reference_for_qc_input_ch)
-        if (params.rki) { 
-            // prepare metadata table
-            rki_report_wf(determine_lineage_wf.out)
-            // collect a multifasta file
-            fasta_input_ch
-                .map { it -> it[1] } 
-                .collectFile(name: 'all_genomes.fasta', storeDir: params.output + "/" + params.rkidir +"/")
-        }
+
+        if (params.rki) { rki_report_wf(determine_lineage_wf.out, genome_quality_wf.out) }
 
 
     // 3. (optional) analyse genomes to references and build tree

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -186,7 +186,7 @@ workflow {
         determine_lineage_wf(fasta_input_ch)
         genome_quality_wf(fasta_input_ch, reference_for_qc_input_ch)
 
-        if (params.rki) { rki_report_wf(determine_lineage_wf.out, genome_quality_wf.out) }
+        if (params.rki) { rki_report_wf(genome_quality_wf.out[0], genome_quality_wf.out[1]) }
 
 
     // 3. (optional) analyse genomes to references and build tree

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -116,6 +116,12 @@ if (!workflow.profile.contains('test_fastq') && !workflow.profile.contains('test
     }
 
 // fastq raw input direct from basecalling
+    if (params.fastq_raw && params.list && !workflow.profile.contains('test_fastq')) { 
+        fastq_dir_ch = Channel
+        .fromPath( params.fastq_raw, checkIfExists: true )
+        .splitCsv()
+        .map { row -> ["${row[0]}", file("${row[1]}", checkIfExists: true, type: 'dir')] }
+    }
     else if (params.fastq_raw && !workflow.profile.contains('test_fastq')) { 
         fastq_dir_ch = Channel
         .fromPath( params.fastq_raw, checkIfExists: true, type: 'dir')

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -34,6 +34,7 @@ if ( params.help ) { exit 0, helpMSG() }
     defaultMSG()
 if ( params.primerV.matches('V1200') ) { v1200_MSG() }
 if ( params.dir || workflow.profile.contains('test_fast5') ) { basecalling() }
+if ( params.rki ==~ "[0-9]+") {rki_true()} else if (params.rki) {rki()}
 
 // profile helps
     if ( workflow.profile == 'standard' ) { exit 1, "NO EXECUTION PROFILE SELECTED, use e.g. [-profile local,docker]" }
@@ -313,7 +314,6 @@ def defaultMSG(){
     log.info """
     SARS-CoV-2 - Workflow
 
-
     \u001B[32mProfile:             $workflow.profile\033[0m
     \033[2mCurrent User:        $workflow.userName
     Nextflow-version:    $nextflow.version
@@ -353,3 +353,20 @@ def basecalling() {
     """.stripIndent()
 }
 
+def rki() {
+    log.info """
+    RKI output activated:
+    \033[2mOutput stored at:    $params.output/$params.rkidir  
+    DEMIS number (seq. lab) not provided [--rki]\u001B[0m
+    \u001B[1;30m______________________________________\033[0m
+    """.stripIndent()
+}
+
+def rki_true() {
+    log.info """
+    RKI output activated:
+    \033[2mOutput stored at:    $params.output/$params.rkidir  
+    DEMIS number:        $params.rki [--rki]\u001B[0m
+    \u001B[1;30m______________________________________\033[0m
+    """.stripIndent()
+}

--- a/workflows/genome_quality.nf
+++ b/workflows/genome_quality.nf
@@ -7,5 +7,6 @@ workflow genome_quality_wf {
     main:
         president(fasta.combine(reference))
     emit:   
-        president.out
+        president.out.valid
+        president.out.invalid
 }

--- a/workflows/process/president.nf
+++ b/workflows/process/president.nf
@@ -1,14 +1,24 @@
 process president {
     label "president"
     publishDir "${params.output}/${params.genomedir}/${name}", mode: 'copy',
-        saveAs: { filename -> if (filename.endsWith(".tsv")) "${name}_seq_ident_check.tsv" }
+        saveAs: { filename -> if (filename.endsWith("${name}_report.tsv")) "${name}_seq_ident_check.tsv" }
     input:
         tuple val(name), path(fasta), path(reference_fasta)
     output:
-        tuple val(name), path("output/${name}_report.tsv"), path("output/*valid.fasta"), optional: true
+        tuple val(name), path("output/${name}_report.tsv"), path("output/*_valid.fasta"), emit: valid
+        tuple val(name), path("output/${name}_report.tsv"), path("output/*_invalid.fasta"), emit: invalid
     script:
         """
         president -r ${reference_fasta} -t ${task.cpus} -q ${fasta} -x ${params.threshold} -p output/${name}
+
+        ## workarounds for current president error on invalid fasta ##
+        if [ ! -f output/${name}_report.tsv ]; then
+            echo "ID	Valid	ACGT Nucleotide identity	ACGT Nucleotide identity (ignoring Ns)	ACGT Nucleotide identity (ignoring non-ACGTNs)	Ambiguous Bases	Query Length	Query #ACGT	Query #IUPAC-ACGT	Query #non-IUPAC:	aligned	passed_initial_qc	Date	reference_length	reference	query" > output/${name}_report.tsv
+            echo "False" >> output/${name}_report.tsv
+            cat ${fasta} > output/${name}_invalid.fasta
+            touch output/${name}_valid.fasta
+        fi
+        ## workaround end ##
         """
 }
 

--- a/workflows/process/president.nf
+++ b/workflows/process/president.nf
@@ -5,7 +5,7 @@ process president {
     input:
         tuple val(name), path(fasta), path(reference_fasta)
     output:
-        tuple val(name), path("output/${name}_report.tsv"), optional: true
+        tuple val(name), path("output/${name}_report.tsv"), path("output/*valid.fasta"), optional: true
     script:
         """
         president -r ${reference_fasta} -t ${task.cpus} -q ${fasta} -x ${params.threshold} -p output/${name}

--- a/workflows/process/rki_report.nf
+++ b/workflows/process/rki_report.nf
@@ -7,7 +7,12 @@ process rki_report {
     output:
         tuple path("rki_report.csv"), path("${readme}")
     script:
+        if (params.rki ==~ "[0-9]+")
         """
         rki_report_parser.sh ${params.rki}
+        """
+        else
+        """
+        rki_report_parser.sh "00000"
         """
 }

--- a/workflows/process/rki_report.nf
+++ b/workflows/process/rki_report.nf
@@ -3,7 +3,7 @@ process rki_report {
     publishDir "${params.output}/${params.rkidir}/valid", mode: 'copy', pattern: "rki_valid_report.csv"
     publishDir "${params.output}/${params.rkidir}", mode: 'copy', pattern: "${readme}"
     input:
-        path(pangolin_data)
+        path(president_data)
         path(readme)
     output:
         path("rki_valid_report.csv"), emit: report
@@ -11,10 +11,22 @@ process rki_report {
     script:
         if (params.rki ==~ "[0-9]+")
         """
-        rki_report_parser.sh ${params.rki} rki_valid_report.csv
+        cat ${president_data} | sed '/Nucleotide identity (ignoring Ns)/d' | sed '/\\False\\b/d' >> all.csv
+
+        if [ -s all.csv ]; then
+                rki_report_parser.sh ${params.rki} all.csv rki_valid_report.csv
+        else
+                touch rki_valid_report.csv
+        fi
         """
         else
         """
-        rki_report_parser.sh "00000" rki_valid_report.csv
+        cat ${president_data} | sed '/Nucleotide identity (ignoring Ns)/d' | sed '/\\False\\b/d' >> all.csv
+
+        if [ -s all.csv ]; then
+            rki_report_parser.sh "00000" all.csv rki_valid_report.csv
+        else
+            touch rki_valid_report.csv
+        fi
         """
 }

--- a/workflows/process/rki_report.nf
+++ b/workflows/process/rki_report.nf
@@ -1,18 +1,20 @@
 process rki_report {
     label "ubuntu"
-    publishDir "${params.output}/${params.rkidir}/", mode: 'copy'
+    publishDir "${params.output}/${params.rkidir}/valid", mode: 'copy', pattern: "rki_valid_report.csv"
+    publishDir "${params.output}/${params.rkidir}", mode: 'copy', pattern: "${readme}"
     input:
         path(pangolin_data)
         path(readme)
     output:
-        tuple path("rki_report.csv"), path("${readme}")
+        path("rki_valid_report.csv"), emit: report
+        path("${readme}"), emit: readme
     script:
         if (params.rki ==~ "[0-9]+")
         """
-        rki_report_parser.sh ${params.rki}
+        rki_report_parser.sh ${params.rki} rki_valid_report.csv
         """
         else
         """
-        rki_report_parser.sh "00000"
+        rki_report_parser.sh "00000" rki_valid_report.csv
         """
 }

--- a/workflows/provide_rki.nf
+++ b/workflows/provide_rki.nf
@@ -2,40 +2,36 @@ include { rki_report } from './process/rki_report'
 
 workflow rki_report_wf {
     take: 
-        pangolin_results
-        president
+        president_valid
+        president_invalid
     main:
         readme_pdf_ch = Channel
         .fromPath(workflow.projectDir + "/data/rki_report/Readme.pdf")
 
-        rki_report(pangolin_results.map{it -> it[1]}.collect(), readme_pdf_ch)
+        rki_report(president_valid.map{it -> it[1]}.collect(), readme_pdf_ch)
     
-        //#### waiting here on president #37 to be fixed
+        /* //waiting here on president #37 to be fixed
         valid_reports = president.map { it -> it[1] }
             .splitCsv(header: true, sep: '\t')
             .filter{ it -> it[1] == 'True' } // only using entries with a "true" value
-            //.map { it -> it [0]} 
-            // modify rki rki_report.out
-            // write to file
+            .map { it -> it [0]} 
+            modify rki rki_report.out
+            write to file
         
         invalid_reports = president.map { it -> it[1] }
             .splitCsv(header: true, sep: '\t')
             .filter{ it -> it[1] == 'False' } // only using entries with a "false" value
-            //.map { it -> it [0]} 
-            // write to file rki_report.out
+            .map { it -> it [0]} 
+            write to file rki_report.out
 
-        //####
+        */
 
         // store valid genomes
-        president.map{it -> it[2]}
-                .flatten()
-                .filter{ it =~ '_valid.fasta' }
-                .collectFile(name: 'valid_genomes.fasta', storeDir: params.output + "/" + params.rkidir +"/valid/")
+        president_valid.map{it -> it[2]}
+            .collectFile(name: 'valid_genomes.fasta', storeDir: params.output + "/" + params.rkidir +"/valid/")
 
-        // store invalid genomes
-        president.map{it -> it[2]}
-            .flatten()
-            .filter{ it =~ '_invalid.fasta' }
+        // // store invalid genomes
+        president_invalid.map{it -> it[2]}
             .collectFile(name: 'invalid_genomes.fasta', storeDir: params.output + "/" + params.rkidir +"/invalid/")
 
 

--- a/workflows/provide_rki.nf
+++ b/workflows/provide_rki.nf
@@ -9,31 +9,16 @@ workflow rki_report_wf {
         .fromPath(workflow.projectDir + "/data/rki_report/Readme.pdf")
 
         rki_report(president_valid.map{it -> it[1]}.collect(), readme_pdf_ch)
-    
-        /* //waiting here on president #37 to be fixed
-        valid_reports = president.map { it -> it[1] }
-            .splitCsv(header: true, sep: '\t')
-            .filter{ it -> it[1] == 'True' } // only using entries with a "true" value
-            .map { it -> it [0]} 
-            modify rki rki_report.out
-            write to file
-        
-        invalid_reports = president.map { it -> it[1] }
-            .splitCsv(header: true, sep: '\t')
-            .filter{ it -> it[1] == 'False' } // only using entries with a "false" value
-            .map { it -> it [0]} 
-            write to file rki_report.out
-
-        */
 
         // store valid genomes
-        president_valid.map{it -> it[2]}
+        channel_tmp1 = president_valid.map{it -> it[2]}
+            .splitText(by:100000000)
             .collectFile(name: 'valid_genomes.fasta', storeDir: params.output + "/" + params.rkidir +"/valid/")
 
-        // // store invalid genomes
-        president_invalid.map{it -> it[2]}
+        // store invalid genomes
+        channel_tmp2 = president_invalid.map{it -> it[2]}
+            .splitText(by:100000000)
             .collectFile(name: 'invalid_genomes.fasta', storeDir: params.output + "/" + params.rkidir +"/invalid/")
-
 
     emit: 
         rki_report.out.report

--- a/workflows/provide_rki.nf
+++ b/workflows/provide_rki.nf
@@ -36,7 +36,7 @@ workflow rki_report_wf {
         president.map{it -> it[2]}
             .flatten()
             .filter{ it =~ '_invalid.fasta' }
-            .collectFile(name: 'valid_genomes.fasta', storeDir: params.output + "/" + params.rkidir +"/invalid/")
+            .collectFile(name: 'invalid_genomes.fasta', storeDir: params.output + "/" + params.rkidir +"/invalid/")
 
 
     emit: 

--- a/workflows/provide_rki.nf
+++ b/workflows/provide_rki.nf
@@ -2,13 +2,43 @@ include { rki_report } from './process/rki_report'
 
 workflow rki_report_wf {
     take: 
-        pangolin_results  
+        pangolin_results
+        president
     main:
         readme_pdf_ch = Channel
         .fromPath(workflow.projectDir + "/data/rki_report/Readme.pdf")
 
         rki_report(pangolin_results.map{it -> it[1]}.collect(), readme_pdf_ch)
+    
+        //#### waiting here on president #37 to be fixed
+        valid_reports = president.map { it -> it[1] }
+            .splitCsv(header: true, sep: '\t')
+            .filter{ it -> it[1] == 'True' } // only using entries with a "true" value
+            //.map { it -> it [0]} 
+            // modify rki rki_report.out
+            // write to file
         
+        invalid_reports = president.map { it -> it[1] }
+            .splitCsv(header: true, sep: '\t')
+            .filter{ it -> it[1] == 'False' } // only using entries with a "false" value
+            //.map { it -> it [0]} 
+            // write to file rki_report.out
+
+        //####
+
+        // store valid genomes
+        president.map{it -> it[2]}
+                .flatten()
+                .filter{ it =~ '_valid.fasta' }
+                .collectFile(name: 'valid_genomes.fasta', storeDir: params.output + "/" + params.rkidir +"/valid/")
+
+        // store invalid genomes
+        president.map{it -> it[2]}
+            .flatten()
+            .filter{ it =~ '_invalid.fasta' }
+            .collectFile(name: 'valid_genomes.fasta', storeDir: params.output + "/" + params.rkidir +"/invalid/")
+
+
     emit: 
-        rki_report.out
+        rki_report.out.report
 } 


### PR DESCRIPTION
* [x] rki bug on channel based fasta merge (only happens with --rki in the google cloud)
* [x] without --rki everything runs fine 

```
[06/0039f3] process > collect_fastq_wf:collect_fas... [100%] 1 of 1 ✔
[8c/7ba227] process > read_qc_wf:nanoplot (1)         [100%] 2 of 2 ✔
[bf/d795a2] process > artic_ncov_wf:filter_fastq_b... [100%] 2 of 2 ✔
[6c/010af7] process > artic_ncov_wf:artic (1)         [100%] 2 of 2 ✔
[90/85ec24] process > artic_ncov_wf:bwa_samtools (1)  [100%] 2 of 2 ✔
[28/9974f2] process > artic_ncov_wf:coverage_plot (2) [  0%] 0 of 2
[15/24fce5] process > determine_lineage_wf:pangoli... [  0%] 0 of 2
[f8/e1d468] process > genome_quality_wf:president (2) [100%] 2 of 2 ✔
[-        ] process > rki_report_wf:rki_report        -
Cannot a find a file system provider for scheme: gs
```
* rki result dir does not contain any fasta might be the cause of this ... maybe publish fasta data directly via president (there should be a "publish dir append option?"