### PR TITLE
Fixes error with only integer-like sample names

### DIFF
--- a/workflows/process/summary_report.nf
+++ b/workflows/process/summary_report.nf
@@ -23,7 +23,7 @@ process summary_report {
         '''
     else
         '''
-        echo '#sample,num_unclassified,num_sarscov2,num_human' > kraken2_results.csv
+        echo 'sample,num_unclassified,num_sarscov2,num_human' > kraken2_results.csv
         for KF in !{kraken2_results}; do
         echo -n "${KF%.kreport}," >> kraken2_results.csv
         NUNCLASS=$(awk -v ORS= '$5=="0" {print $3 "," }' $KF)


### PR DESCRIPTION
- force dtype string in all table indexes
- also removed # from header line in kraken aggregate file for robust column selection

tidbits:
the dtype='xx' parameter is actually ineffectual because they get overwritten in the index constructor .... (https://github.com/pandas-dev/pandas/issues/9435)