### PR TITLE
nanopolish wo basecalling, improv errorhandling

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest {
 // default parameters
 params {
     max_cores = Runtime.runtime.availableProcessors()
-    cores = Runtime.runtime.availableProcessors()
+    cores = Runtime.runtime.availableProcessors().intdiv(4)
     memory = '12'
     help = false
     profile = false
@@ -33,7 +33,7 @@ params {
     krakendb = ''
     localguppy = false
     medaka_model = 'r941_min_high_g360'
-    nanopolish = false
+    nanopolish = ''
     one_end = false
     single = false
 

--- a/workflows/artic_nanopore_nCov19.nf
+++ b/workflows/artic_nanopore_nCov19.nf
@@ -23,8 +23,7 @@ workflow artic_ncov_wf {
                 assembly.join(filter_fastq_by_length.out))[0])
 
         // error logging
-        noreadsatall = filter_fastq_by_length.out.ifEmpty("\033[0;33mNot enough reads in all samples, please investigate $params.output/$params.readqcdir\033[0m")
-            .filter( "\033[0;33mNot enough reads in all samples, please investigate $params.output/$params.readqcdir\033[0m" ).view()
+        noreadsatall = filter_fastq_by_length.out.ifEmpty{ println "\033[0;33mNot enough reads in all samples, please investigate $params.output/$params.readqcdir\033[0m" }
 
     emit:   
         assembly
@@ -56,7 +55,7 @@ workflow artic_ncov_np_wf {
                 assembly.join(filter_fastq_by_length.out))[0])
 
         // error logging
-        noreadsatall = filter_fastq_by_length.out.ifEmpty("\033[0;33mNot enough reads in all samples, please investigate $params.output/$params.readqcdir\033[0m").view()
+        noreadsatall = filter_fastq_by_length.out.ifEmpty{ println "\033[0;33mNot enough reads in all samples, please investigate $params.output/$params.readqcdir\033[0m" }
 
     emit:   
         assembly

--- a/workflows/process/artic.nf
+++ b/workflows/process/artic.nf
@@ -35,7 +35,7 @@ process artic_nanopolish {
             --scheme-directory ${external_scheme} \
             --read-file ${reads} \
             --fast5-directory ${fast5_dir} \
-            --sequencing-summary sequencing_summary.txt \
+            --sequencing-summary sequencing_summary*.txt \
             nCoV-2019/${params.primerV} ${name}
 
         zcat ${name}.pass.vcf.gz > SNP_${name}.pass.vcf

--- a/workflows/process/collect_fastq.nf
+++ b/workflows/process/collect_fastq.nf
@@ -3,7 +3,7 @@ process collect_fastq {
     input:
         tuple val(name), path(dir)
     output:
-        tuple val(name), path("*.fastq.gz"), emit: reads 
+        tuple val(name), path("*.fastq.gz"), emit: reads
     script:
         if (params.single)
         """


### PR DESCRIPTION
* closes #94
   * sequencing summary is provided via `--nanopolish` and it is only necessary if `--fastq` or `--fastq_pass` is provided
* did some small test runs and works fine
* added more verbose error codes throughout the workflow
* needs some proper testing to validate if all workflows are chosen correctly
* @iferres would be glad if you could do some testing

```bash
# update poreCov
nextflow pull replikation/poreCov
# example run (please add profile etc.)
nextflow run replikation/poreCov  -r no_basecall_nanopolish --fast5 fast5_dir/ --fastq_pass fastq_pass/ --nanopolish sequencing_summary.txt 
```

