### PR TITLE
rki_report patch

### DIFF
--- a/bin/rki_report_parser_extended.sh
+++ b/bin/rki_report_parser_extended.sh
@@ -8,11 +8,11 @@ EXTENDED_TABLE=$3
 echo "SENDING_LAB;DATE_DRAW;SEQ_TYPE;SEQ_REASON;SAMPLE_TYPE;PUBLICATION_STATUS;OWN_FASTA_ID" > $OUTPUT_NAME
 
 while IFS=$'\t' read -r -a Array; do
-    SENDING_LAB=$(grep "${Array[0]}" ${EXTENDED_TABLE} | cut -f 2 -d ",")
-    DATE_DRAW=$(grep "${Array[0]}" ${EXTENDED_TABLE} | cut -f 3 -d ",")
+    SENDING_LAB=$(grep -w "${Array[0]}" ${EXTENDED_TABLE} | cut -f 2 -d ",")
+    DATE_DRAW=$(grep -w "${Array[0]}" ${EXTENDED_TABLE} | cut -f 3 -d ",")
     SEQU_TECH=$(echo "OXFORD_NANOPORE")
-    SEQU_REASON=$(grep "${Array[0]}" ${EXTENDED_TABLE} | cut -f 4 -d ",")
-    SAMPLE_TYPE=$(grep "${Array[0]}" ${EXTENDED_TABLE} | cut -f 5 -d ",")
+    SEQU_REASON=$(grep -w "${Array[0]}" ${EXTENDED_TABLE} | cut -f 4 -d ",")
+    SAMPLE_TYPE=$(grep -w "${Array[0]}" ${EXTENDED_TABLE} | cut -f 5 -d ",")
     OWN_FASTA_ID="${Array[0]}"
     echo "${SENDING_LAB};${DATE_DRAW};${SEQU_TECH};${SEQU_REASON};${SAMPLE_TYPE};N;${OWN_FASTA_ID}" >> $OUTPUT_NAME
 done < ${INPUT_NAME}


### PR DESCRIPTION
Fixing the bug of fragmented rki-report after using two times a similar, but not identical, hash_ids,
e.g.: "609270253d108d14e2765716" & "609270253d108d14e2765716_2"

 