### PR TITLE
Split fasta improvment

### DIFF
--- a/bin/split_fasta.py
+++ b/bin/split_fasta.py
@@ -41,7 +41,7 @@ for fasta_file in sys.argv[1:]:
                 if seq_name in sequence_names:
                     log(f'WARNING: Duplicate sequence name: {seq_name}')
                     # add number to seq_name, according to how often seq_name alrready appeared
-                    duplicate_seq_name_pattern = f'{seq_name}_duplicate**'
+                    duplicate_seq_name_pattern = f'{seq_name}_duplicate*'
                     seq_name += f'_duplicate{int(len([item for item in sequence_names if item == seq_name or fnmatch.fnmatch(item ,duplicate_seq_name_pattern)])):02d}'
                 
                 # save

--- a/bin/split_fasta.py
+++ b/bin/split_fasta.py
@@ -17,7 +17,6 @@ def log(string, newline_before=False):
 
 fasta_files = []
 sequence_names = []
-duplicates = []
 outfh = None
 
 for fasta_file in sys.argv[1:]:
@@ -40,7 +39,8 @@ for fasta_file in sys.argv[1:]:
                 # handle duplicates
                 if seq_name in sequence_names:
                     log(f'WARNING: Duplicate sequence name: {seq_name}')
-                    seq_name += f'_{int(len([item for item in sequence_names if seq_name in item])):02d}'
+                    # add number to seq_name, according to how often seq_name alrready appeared
+                    seq_name += f'_duplicate{int(len([item for item in sequence_names if seq_name in item])):02d}'
                 
                 # save
                 sequence_names.append(seq_name)

--- a/bin/split_fasta.py
+++ b/bin/split_fasta.py
@@ -35,17 +35,13 @@ for fasta_file in sys.argv[1:]:
                 assert seq_name != '', f'Empty header in file: {fasta_file}'
                 
                 # sanitize
-                seq_name = seq_name.replace(' ','_').replace('/', '_').replace(':', '_').replace('|','_')
+                seq_name = seq_name.replace('/', '_').replace(':', '_').replace('|','_')
 
                 # handle duplicates
                 if seq_name in sequence_names:
                     log(f'WARNING: Duplicate sequence name: {seq_name}')
-                    sname, ncount = seq_name.rsplit('_',1)
-                    if sname in duplicates:
-                        seq_name = sname + f'_{int(ncount):02d}'
-                    else:
-                        duplicates.append(seq_name)
-                        seq_name += '_02'
+                    seq_name += f'_{int(len([item for item in sequence_names if seq_name in item])):02d}'
+                
                 # save
                 sequence_names.append(seq_name)
 

--- a/bin/split_fasta.py
+++ b/bin/split_fasta.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import fnmatch
 
 def error(string, error_type=1):
     sys.stderr.write(f'ERROR: {string}\n')
@@ -40,7 +41,8 @@ for fasta_file in sys.argv[1:]:
                 if seq_name in sequence_names:
                     log(f'WARNING: Duplicate sequence name: {seq_name}')
                     # add number to seq_name, according to how often seq_name alrready appeared
-                    seq_name += f'_duplicate{int(len([item for item in sequence_names if seq_name in item])):02d}'
+                    duplicate_seq_name_pattern = f'{seq_name}_duplicate**'
+                    seq_name += f'_duplicate{int(len([item for item in sequence_names if item == seq_name or fnmatch.fnmatch(item ,duplicate_seq_name_pattern)])):02d}'
                 
                 # save
                 sequence_names.append(seq_name)


### PR DESCRIPTION
Overhauled duplicate handling in split_fasta.py to handle multi-fastas where the same sequence(-name) appears multiple times.
sname & ncount-route of the if-statement wasn´t properly working for my test-file.
Also all appearances of a sequence after the first would be melted down into a single second entry, which then was handed over to following processes. E.g.: a multifasta with 4 times the same sequence-name ('>sampleX') would only create two follow-processes ('sampleX' & 'sampleX_02') instead of one per appearance. 