### PR TITLE
update medaka models

### DIFF
--- a/configs/container.config
+++ b/configs/container.config
@@ -1,7 +1,7 @@
 process {
     // DONT add GUPPY containers here !!! they are maintained via process
     // pangolin container is maintained via params.defaultpangolin in nextflow.config
-    withLabel:  artic       { container = 'nanozoo/artic:1.3.0-dev--e51531c' }
+    withLabel:  artic       { container = 'nanozoo/artic:1.3.0-dev--f714f62' }
     withLabel:  bwa         { container = 'nanozoo/bwa:0.7.17--d11c0a4' }
     withLabel:  covarplot   { container = 'nanozoo/covarplot:0.0.2--2c6e300' }
     withLabel:  demultiplex { container = 'nanozoo/guppy_cpu:5.0.7-1--47b84be' }


### PR DESCRIPTION
* updated the ARTIC container to also include all available models for medaka directly
* thus, no internet connection is needed to pull non-default medaka models and all is in the container already

Tested on cluster machine that is behind a firewall, worked

```
nextflow run poreCov/poreCov.nf -profile local,singularity -params-file run.yml -w work --update --medaka_model r941_min_high_g360 --guppy_model dna_r9.4.1_450bps_sup.cfg --output results_sup_hac -resume
```

suggestion to do a v0.10.1 release then