### PR TITLE
add wildcard to also detect new V4 depth files

### DIFF
--- a/workflows/process/artic.nf
+++ b/workflows/process/artic.nf
@@ -10,7 +10,7 @@ process artic_medaka {
         tuple val(name), path("*.consensus.fasta"), emit: fasta
         tuple val(name), path("${name}_mapped_*.primertrimmed.sorted.bam"), path("${name}_mapped_*.primertrimmed.sorted.bam.bai"), emit: reference_bam
         tuple val(name), path("SNP_${name}.pass.vcf"), emit: vcf
-        tuple val(name), path("${name}.pass.vcf.gz"), path("${name}.coverage_mask.txt.nCoV-2019_1.depths"), path("${name}.coverage_mask.txt.nCoV-2019_2.depths"), emit: covarplot
+        tuple val(name), path("${name}.pass.vcf.gz"), path("${name}.coverage_mask.txt.*1.depths"), path("${name}.coverage_mask.txt.*2.depths"), emit: covarplot
     script:   
         """
         artic minion    --medaka \


### PR DESCRIPTION
* apparently the new V4 primer scheme generates some differently named coverage depth files that are needed for CoVerage