### PR TITLE
Add guppy/medaka models, print out 'Description' column

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,31 @@
 Table of Contents
 =================
 <!--ts-->
-* [1. Quick Setup (Ubuntu)](#1-quick-setup-ubuntu)
-    * [1.1 Nextflow](#11-nextflow-the-workflow-manager)
-    * [1.2 Container](#12-container-choose-one---they-manage-all-the-tools)
-    * [1.3 Basecalling (optional)](#13-basecalling-optional)
-* [2. Run poreCov](#2-run-porecov)
-    * [2.1 Test run](#21-test-run)
-    * [2.2 Quick run examples](#22-quick-run-examples)
-    * [2.3 Extended Usage](#23-extended-usage)
-* [3. Quality Metrics (default)](#3-quality-metrics-default)
-* [4. Workflow](#4-workflow)
-* [5. Literature / References to cite](#5-literature--references-to-cite)
-* [6. Troubleshooting](#6-troubleshooting)
-* [7. Time to results](#7-time-to-results)
-* [8. Credits](#8-credits)
+- [**poreCov | SARS-CoV-2 Workflow for nanopore sequencing data**](#porecov--sars-cov-2-workflow-for-nanopore-sequencing-data)
+  - [What is this Repo?](#what-is-this-repo)
+- [Table of Contents](#table-of-contents)
+- [1. Quick Setup (Ubuntu)](#1-quick-setup-ubuntu)
+  - [1.1 Nextflow (the workflow manager)](#11-nextflow-the-workflow-manager)
+  - [1.2 Container (choose one - they manage all the tools)](#12-container-choose-one---they-manage-all-the-tools)
+    - [Docker](#docker)
+    - [Singularity](#singularity)
+    - [Conda (not recommended)](#conda-not-recommended)
+  - [1.3 Basecalling (optional)](#13-basecalling-optional)
+- [2. Run poreCov](#2-run-porecov)
+  - [2.1 Test run](#21-test-run)
+  - [2.2 Quick run examples](#22-quick-run-examples)
+  - [2.3 Extended Usage](#23-extended-usage)
+    - [Version control](#version-control)
+    - [Important input flags (choose one)](#important-input-flags-choose-one)
+    - [Sample sheet](#sample-sheet)
+    - [Pangolin Lineage definitions](#pangolin-lineage-definitions)
+- [3. Quality Metrics (default)](#3-quality-metrics-default)
+- [4. Workflow](#4-workflow)
+- [5. Literature / References to cite](#5-literature--references-to-cite)
+- [6. Troubleshooting](#6-troubleshooting)
+  - [Singularity](#singularity-1)
+- [7. Time to results](#7-time-to-results)
+- [8. Credits](#8-credits)
 <!--te-->
 
   # 1. Quick Setup (Ubuntu)
@@ -127,14 +138,17 @@ nextflow run replikation/poreCov --fast5 fast5_dir/ --samples sample_names.csv \
 
 ### Sample sheet
 * barcodes can be automatically renamed via `--samples sample_names.csv`
-* example comma separated file (don't replace the header)
+* required columns:
   * `_id` = sample name
   * `Status` = barcode number which should be renamed
+* optional column:
+  * `Description` = description column to be included in the output report and tables
 
+Example comma separated file (don't replace the header):
 ```csv
-_id,Status
-Sample_2021,barcode01
-2ndSample,BC02
+_id,Status,Description
+Sample_2021,barcode01,good
+2ndSample,BC02,bad
 ```
   
 ### Pangolin Lineage definitions

--- a/bin/summary_report.py
+++ b/bin/summary_report.py
@@ -550,6 +550,9 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Generate a summary report for multiple samples run with poreCov')
     parser.add_argument("-v", "--version_config", help="version config", required=True)
     parser.add_argument("--porecov_version", help="porecov version", required=True)
+    parser.add_argument("--guppy_used", help="guppy used")
+    parser.add_argument("--guppy_model", help="guppy model")
+    parser.add_argument("--medaka_model", help="medaka model")
     parser.add_argument("--pangolin_docker", help="pangolin/pangoLEARN version", required=True)
     parser.add_argument("--primer", help="primer version")
     parser.add_argument("-p", "--pangolin_results", help="pangolin results")
@@ -594,11 +597,16 @@ if __name__ == '__main__':
 
     # check run type
     if args.primer:
-        report.add_param('Run type', "Genome reconstruction and classification from sequencing reads (input with '--fast5', '--fastq' or '--fastq_raw')")
+        
+        report.add_param('Run type', "Genome reconstruction and classification from raw sequencing data " + ("(fast5)" if args.guppy_used == 'true' else "(fastq)"))
         report.add_param('<a href="https://artic.network/ncov-2019">ARTIC</a> version', report.tool_versions['artic'])
         report.add_param('ARTIC primer version', args.primer)
+        if args.guppy_used == 'true':
+            report.add_param('Guppy model', args.guppy_model)
+        if args.medaka_model:
+            report.add_param('Medaka model', args.medaka_model)
     else:
-        report.add_param('Run type', "Genome classification from sequences (input with '--fasta')")
+        report.add_param('Run type', "Genome classification from sequences (input with '--fasta' or from test_fasta profile)")
     report.add_time_param()
 
     report.write_html_report()

--- a/bin/summary_report.py
+++ b/bin/summary_report.py
@@ -42,6 +42,7 @@ class SummaryReport():
     sample_QC_status = None
     sample_QC_info = {}
     control_string_patterns = ['control', 'negative']
+    samples_table = None
 
 
     # colors
@@ -134,16 +135,25 @@ class SummaryReport():
 
 
     def check_and_init_table_with_samples(self, samples):
-        if samples != 'samples_list.csv':
+
+        print(samples)
+        if samples == 'deactivated':
             log('No sample list input.')
         else:
             log('Using samples input.')
-            s_list = [s.strip() for s in open(samples).readlines()]
+            self.samples_table = pd.read_csv(samples, index_col='_id')
+
+            s_list = list(self.samples_table.index)
             log(f'Samples: {s_list}')
 
             s_table = pd.DataFrame(index=s_list)
             self.force_index_dtype_string(s_table)
             self.check_and_init_tabledata(s_table.index)
+
+            # add description column if present
+            if 'Description' in self.samples_table.columns:
+                self.add_column_raw('Description', self.samples_table['Description'])
+                self.add_column('Description', self.samples_table['Description'])
 
 
     def check_and_init_tabledata(self, t_index):

--- a/bin/summary_report.py
+++ b/bin/summary_report.py
@@ -284,7 +284,7 @@ class SummaryReport():
         self.add_column_raw('pangolin_lineage', res_data['lineage'])
         self.add_column_raw('pangolin_conflict', res_data['conflict'])
 
-        res_data['lineage_conflict'] = [f'<b>{l}</b><br>({p:.2f})' for l,p in zip(res_data['lineage'], res_data['conflict'])]
+        res_data['lineage_conflict'] = [f'<b>{l}</b><br>({p if pd.notnull(p) else "-"})' for l,p in zip(res_data['lineage'], res_data['conflict'])]
 
         self.add_column('Lineage<br>(conflict)', res_data['lineage_conflict'])
         if self.pangolin_version is None or self.pangolearn_version is None:

--- a/bin/summary_report.py
+++ b/bin/summary_report.py
@@ -598,15 +598,17 @@ if __name__ == '__main__':
     # check run type
     if args.primer:
         
+        # infer run type from guppy usage
         report.add_param('Run type', "Genome reconstruction and classification from raw sequencing data " + ("(fast5)" if args.guppy_used == 'true' else "(fastq)"))
         report.add_param('<a href="https://artic.network/ncov-2019">ARTIC</a> version', report.tool_versions['artic'])
         report.add_param('ARTIC primer version', args.primer)
-        if args.guppy_used == 'true':
+        # add guppy/medaka model if used
+        if args.guppy_model and args.guppy_used == 'true':
             report.add_param('Guppy model', args.guppy_model)
         if args.medaka_model:
             report.add_param('Medaka model', args.medaka_model)
     else:
-        report.add_param('Run type', "Genome classification from sequences (input with '--fasta' or from test_fasta profile)")
+        report.add_param('Run type', "Genome classification from sequences (fasta)")
     report.add_time_param()
 
     report.write_html_report()

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -363,12 +363,12 @@ workflow {
         }
 
         if (params.samples) {
-            samples_list_ch = Channel.fromPath( params.samples, checkIfExists: true)
+            samples_table_ch = Channel.fromPath( params.samples, checkIfExists: true)
         }
-        else { samples_list_ch = Channel.from( ['deactivated'] ) }
+        else { samples_table_ch = Channel.from( ['deactivated'] ) }
 
         create_summary_report_wf(determine_lineage_wf.out, genome_quality_wf.out[0], determine_mutations_wf.out,
-                                read_classification_ch, alignments_ch, samples_list_ch)
+                                read_classification_ch, alignments_ch, samples_table_ch)
 
 }
 
@@ -384,7 +384,7 @@ def helpMSG() {
     log.info """
     .    
 \033[0;33mUsage examples:${c_reset}
-    nextflow run replikation/poreCov --fastq '*.fasta.gz' -r 0.8.0 -profile local,singularity
+    nextflow run replikation/poreCov --fastq '*.fasta.gz' -r 0.9.5 -profile local,singularity
 
 ${c_yellow}Inputs (choose one):${c_reset}
     --fast5         one fast5 dir of a nanopore run containing multiple samples (barcoded);

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -363,7 +363,7 @@ workflow {
         }
 
         if (params.samples) {
-            samples_list_ch = samples_input_ch.map{ it -> it[1] }.collectFile(name: 'samples_list.csv', newLine: true)
+            samples_list_ch = Channel.fromPath( params.samples, checkIfExists: true)
         }
         else { samples_list_ch = Channel.from( ['deactivated'] ) }
 

--- a/workflows/create_summary_report.nf
+++ b/workflows/create_summary_report.nf
@@ -8,7 +8,7 @@ workflow create_summary_report_wf {
         nextclade
         kraken2
         alignments
-        samples_list
+        samples_table
         main:
         version_ch = Channel.fromPath(workflow.projectDir + "/configs/container.config")
 
@@ -27,7 +27,7 @@ workflow create_summary_report_wf {
             coverage_plots = plot_coverages(alignments.map{it -> it[0]}.toSortedList({ a, b -> a.simpleName <=> b.simpleName }).flatten().collate(6), \
                                             alignments.map{it -> it[1]}.toSortedList({ a, b -> a.simpleName <=> b.simpleName }).flatten().collate(6)).collect()
 
-            if (params.samples) { summary_report(version_ch, pangolin_results, president_results, nextclade_results, kraken2_results, coverage_plots, samples_list) }
+            if (params.samples) { summary_report(version_ch, pangolin_results, president_results, nextclade_results, kraken2_results, coverage_plots, samples_table) }
             else { summary_report_default(version_ch, pangolin_results, president_results, nextclade_results, kraken2_results, coverage_plots) }
             
         }

--- a/workflows/process/summary_report.nf
+++ b/workflows/process/summary_report.nf
@@ -10,7 +10,7 @@ process summary_report {
         path(nextclade_results)
         file(kraken2_results)
         file(coverage_plots)
-        file(samples_list)
+        file(samples_table)
     output:
 	    path("poreCov_summary_report_*.html")
         path("poreCov_summary_report_*.xlsx")
@@ -41,7 +41,7 @@ process summary_report {
             -n !{nextclade_results} \
             -k kraken2_results.csv \
             -c $(echo !{coverage_plots} | tr ' ' ',') \
-            -s !{samples_list}
+            -s !{samples_table}
         '''
     stub:
         """

--- a/workflows/process/summary_report.nf
+++ b/workflows/process/summary_report.nf
@@ -1,6 +1,8 @@
 process summary_report {
-        publishDir "${params.output}/", mode: 'copy'
-        label 'fastcov'
+
+    publishDir "${params.output}/", mode: 'copy'
+    label 'fastcov'
+    
     input:
         path(version_config)
         path(pangolin_results)
@@ -14,10 +16,8 @@ process summary_report {
         path("poreCov_summary_report_*.xlsx")
         path("poreCov_summary_report_*.tsv")
 
-
     shell:
-
-        guppyused = (params.fast5 || workflow.profile.contains('test_fast5')
+        guppyused = (params.fast5 || workflow.profile.contains('test_fast5'))
 
         '''
         echo 'sample,num_unclassified,num_sarscov2,num_human' > kraken2_results.csv
@@ -34,7 +34,7 @@ process summary_report {
             --guppy_used !{guppyused} \
             --guppy_model !{params.guppy_model} \
             --medaka_model !{params.medaka_model} \
-	        --pangolin_docker !{params.pangolindocker} \
+            --pangolin_docker !{params.pangolindocker} \
             --primer !{params.primerV} \
             -p !{pangolin_results} \
             -q !{president_results} \
@@ -50,8 +50,10 @@ process summary_report {
 }
 
 process summary_report_default {
-        publishDir "${params.output}/", mode: 'copy'
-        label 'fastcov'
+
+    publishDir "${params.output}/", mode: 'copy'
+    label 'fastcov'
+    
     input:
         path(version_config)
         path(pangolin_results)
@@ -65,8 +67,7 @@ process summary_report_default {
         path("poreCov_summary_report_*.tsv")
 
     shell:
-
-        guppyused = (params.fast5 || workflow.profile.contains('test_fast5')
+        guppyused = (params.fast5 || workflow.profile.contains('test_fast5'))
 
         '''
         echo 'sample,num_unclassified,num_sarscov2,num_human' > kraken2_results.csv

--- a/workflows/process/summary_report.nf
+++ b/workflows/process/summary_report.nf
@@ -14,7 +14,11 @@ process summary_report {
         path("poreCov_summary_report_*.xlsx")
         path("poreCov_summary_report_*.tsv")
 
+
     shell:
+
+        guppyused = (params.fast5 || workflow.profile.contains('test_fast5')
+
         '''
         echo 'sample,num_unclassified,num_sarscov2,num_human' > kraken2_results.csv
         for KF in !{kraken2_results}; do
@@ -27,7 +31,10 @@ process summary_report {
         summary_report.py \
             -v !{version_config} \
             --porecov_version !{workflow.revision}:!{workflow.commitId}:!{workflow.scriptId} \
-	    --pangolin_docker !{params.pangolindocker} \
+            --guppy_used !{guppyused} \
+            --guppy_model !{params.guppy_model} \
+            --medaka_model !{params.medaka_model} \
+	        --pangolin_docker !{params.pangolindocker} \
             --primer !{params.primerV} \
             -p !{pangolin_results} \
             -q !{president_results} \
@@ -58,6 +65,9 @@ process summary_report_default {
         path("poreCov_summary_report_*.tsv")
 
     shell:
+
+        guppyused = (params.fast5 || workflow.profile.contains('test_fast5')
+
         '''
         echo 'sample,num_unclassified,num_sarscov2,num_human' > kraken2_results.csv
         for KF in !{kraken2_results}; do
@@ -70,6 +80,9 @@ process summary_report_default {
         summary_report.py \
             -v !{version_config} \
             --porecov_version !{workflow.revision}:!{workflow.commitId}:!{workflow.scriptId} \
+            --guppy_used !{guppyused} \
+            --guppy_model !{params.guppy_model} \
+            --medaka_model !{params.medaka_model} \
             --pangolin_docker !{params.pangolindocker} \
             --primer !{params.primerV} \
             -p !{pangolin_results} \


### PR DESCRIPTION
Fixes #136
(and half of #142)

Report now includes:
- Guppy model if basecalling from fast5
- Medaka model if ARTIC is run (just realised that this is misleading/wrong if using nanopolish)
- If providing a samples.csv: If a column is named exactly 'Description', it is added to the output tables (this could be extended to others, or allow selection of the columns via parameters)

![image](https://user-images.githubusercontent.com/29630353/133267906-e07749a1-30ef-4384-a772-9442cb0045fc.png)
