### PR TITLE
fix output channel for nanopolish

### DIFF
--- a/workflows/process/artic.nf
+++ b/workflows/process/artic.nf
@@ -61,7 +61,7 @@ process artic_nanopolish {
         tuple val(name), path("*.consensus.fasta"), emit: fasta
         tuple val(name), path("${name}_mapped_*.primertrimmed.sorted.bam"), path("${name}_mapped_*.primertrimmed.sorted.bam.bai"), emit: reference_bam
         tuple val(name), path("SNP_${name}.pass.vcf"), emit: vcf
-        tuple val(name), path("${name}.pass.vcf.gz"), path("${name}.coverage_mask.txt.nCoV-2019_1.depths"), path("${name}.coverage_mask.txt.nCoV-2019_2.depths"), emit: covarplot
+        tuple val(name), path("${name}.pass.vcf.gz"), path("${name}.coverage_mask.txt.*1.depths"), path("${name}.coverage_mask.txt.*2.depths"), emit: covarplot
     script:   
         """
         artic minion --minimap2 --normalise 500 \


### PR DESCRIPTION
It seems no one was using `nanopolish` for a while ;) 

The output channel for the coverage depth files needed adjustment, similar to the default `medaka` process a while ago. The files were renamed in some ARTIC update. 

Works for me, just did a run with `nanopolish`. So ready to merge and doing a minor release from my side. 