### PR TITLE
Guppy adjustments for HPC (SLURM) execution

### DIFF
--- a/workflows/process/guppy.nf
+++ b/workflows/process/guppy.nf
@@ -2,7 +2,7 @@ process guppy_gpu {
     label 'guppy_gpu'
         if (!params.localguppy) {
 	    if (workflow.profile.contains('slurm')) {
-		clusterOptions = '--gpus=1'
+		clusterOptions = '--gpus=1 --time=06:00:00'
 	    }
             if (workflow.profile.contains('docker')) {
                 container = 'nanozoo/guppy_gpu:5.0.7-1--ec2c6e7'

--- a/workflows/process/guppy.nf
+++ b/workflows/process/guppy.nf
@@ -53,7 +53,7 @@ process guppy_gpu {
             }
         if (params.single)
         """
-        guppy_basecaller -c ${params.guppy_model} -i ${dir} -s fastq -x auto -r --trim_strategy dna -q 0
+        guppy_basecaller -c ${params.guppy_model} -i ${dir} -s fastq -x auto -r --trim_strategy dna -q 0 --disable_pings
 
         find -L fastq -name '*.fastq' -exec cat {} +  | gzip > ${name}.fastq.gz
         
@@ -62,8 +62,8 @@ process guppy_gpu {
         """
         else
         """
-        guppy_basecaller -c ${params.guppy_model} -i ${dir} -s fastq_tmp -x auto -r
-        guppy_barcoder -t ${task.cpus} -r ${barcoding_option} -i fastq_tmp -s fastq --arrangements_files "${guppy_arrangement_files}"
+        guppy_basecaller -c ${params.guppy_model} -i ${dir} -s fastq_tmp -x auto -r --disable_pings
+        guppy_barcoder -t ${task.cpus} -r ${barcoding_option} -i fastq_tmp -s fastq --arrangements_files "${guppy_arrangement_files}" --disable_pings
 
         for barcodes in fastq/barcode??; do
             find -L \${barcodes} -name '*.fastq' -exec cat {} + | gzip > \${barcodes##*/}.fastq.gz
@@ -105,7 +105,7 @@ process guppy_cpu {
             }
         if (params.single)
         """
-        guppy_basecaller -c ${params.guppy_model} -i ${dir} -s fastq  --num_callers ${task.cpus} --cpu_threads_per_caller 1 -r --trim_strategy dna -q 0
+        guppy_basecaller -c ${params.guppy_model} -i ${dir} -s fastq  --num_callers ${task.cpus} --cpu_threads_per_caller 1 -r --trim_strategy dna -q 0 --disable_pings
 
         find -L fastq -name '*.fastq' -exec cat {} +  | gzip > ${name}.fastq.gz
         
@@ -114,8 +114,8 @@ process guppy_cpu {
         """
         else
         """
-        guppy_basecaller -c ${params.guppy_model} -i ${dir} -s fastq_tmp  --num_callers ${task.cpus} --cpu_threads_per_caller 1 -r
-        guppy_barcoder -t ${task.cpus} -r ${barcoding_option} -i fastq_tmp -s fastq --arrangements_files "${guppy_arrangement_files}"
+        guppy_basecaller -c ${params.guppy_model} -i ${dir} -s fastq_tmp  --num_callers ${task.cpus} --cpu_threads_per_caller 1 -r --disable_pings
+        guppy_barcoder -t ${task.cpus} -r ${barcoding_option} -i fastq_tmp -s fastq --arrangements_files "${guppy_arrangement_files}" --disable_pings
 
         for barcodes in fastq/barcode??; do
             find -L \${barcodes} -name '*.fastq' -exec cat {} + | gzip > \${barcodes##*/}.fastq.gz

--- a/workflows/process/guppy.nf
+++ b/workflows/process/guppy.nf
@@ -1,6 +1,9 @@
 process guppy_gpu {
     label 'guppy_gpu'
         if (!params.localguppy) {
+	    if (workflow.profile.contains('slurm')) {
+		clusterOptions = '--gpus=1'
+	    }
             if (workflow.profile.contains('docker')) {
                 container = 'nanozoo/guppy_gpu:5.0.7-1--ec2c6e7'
                 containerOptions '--gpus all'


### PR DESCRIPTION
I had to adjust some parameters to get Guppy running on an HPC cluster node via SLURM and with URL restrictions but I think this is generally useful for executing poreCov w/ basecalling on SLURM

1) use `--disable_pings` for the guppy commands to just not send information to ONT ;) 
2) add clusterOptions for SLURM to give the basecalling process enough time (otherwise the job might be killed depending on the SLURM configuration)