### PR TITLE
bump Medaka version in ARTIC container

### DIFF
--- a/configs/container.config
+++ b/configs/container.config
@@ -2,7 +2,7 @@ process {
     // DONT add GUPPY containers here !!! they are maintained via process
     // pangolin container is maintained via params.defaultpangolin in nextflow.config
     // nextclade container is maintained via params.defaultpangolin in nextflow.config
-    withLabel:  artic       { container = 'nanozoo/artic:1.3.0-dev--f714f62' }
+    withLabel:  artic       { container = 'nanozoo/artic:1.3.0-dev--2c5b6a9' }
     withLabel:  bwa         { container = 'nanozoo/bwa:0.7.17--d11c0a4' }
     withLabel:  covarplot   { container = 'nanozoo/covarplot:0.0.2--2c6e300' }
     withLabel:  demultiplex { container = 'nanozoo/guppy_cpu:5.0.7-1--47b84be' }


### PR DESCRIPTION
Updated Medaka to version 1.5.0 inside the ARTIC workflow (container). Before, the version was 1.4.3

This was an attempt to fix an issue w/ BA.1 and a Deletion causing a frameshift - but this did not help. However, might be not bad to update Medaka at some time. 