### PR TITLE
Pangolin4 update

### DIFF
--- a/bin/summary_report.py
+++ b/bin/summary_report.py
@@ -38,7 +38,7 @@ class SummaryReport():
     scorpio_constellations_version = None
     variants_table = None
     pangolin_version = None
-    pangolearn_version = None
+    pangolindata_version = None
     nextclade_version = None
     nextcladedata_version = None
     tabledata = None
@@ -110,14 +110,14 @@ class SummaryReport():
 
 
     def add_pangolin_version_param(self):
-        if self.pangolearn_version is None:
+        if self.pangolindata_version is None:
             error('add_pangolin_version_param() called before pangolin version was set')
-        warning_msg = f' - <font color="{self.color_error_red}"><b>Warning</b>: A rather old version of PangoLEARN was used ({self.pangolearn_version}). Use parameter \'--update\' to force the use of the most recent Pangolin container!</font>'
+        warning_msg = f' - <font color="{self.color_error_red}"><b>Warning</b>: A rather old version of pangolin-data was used ({self.pangolindata_version}). Use parameter \'--update\' to force the use of the most recent Pangolin container!</font>'
         
-        pl_param = f'<a href="https://cov-lineages.org/resources/pangolin/pangolearn.html"><b>PangoLEARN</b></a> version'
-        pl_val = f'{self.pangolearn_version}'
+        pl_param = f'<a href="https://cov-lineages.org/resources/pangolin/requirements.html"><b>pangolin-data</b></a> version'
+        pl_val = f'{self.pangolindata_version}'
 
-        year, month, day = self.pangolearn_version.split('-')
+        year, month, day = self.pangolindata_version.split('-')
         if int(year) <= 2021 and int(month) <= 10:
             pl_val += warning_msg
 
@@ -361,7 +361,7 @@ class SummaryReport():
         # pangolin and scorpio versions
         assert res_data.shape[0] > 0
         self.pangolin_version = res_data.loc[0]['pangolin_version']
-        self.pangolearn_version = res_data.loc[0]['version']
+        self.pangolindata_version = res_data.loc[0]['version']
         self.scorpio_version = res_data.loc[0]['scorpio_version']
         self.scorpio_constellations_version = res_data.loc[0]['constellation_version']
 
@@ -392,9 +392,9 @@ class SummaryReport():
 
 
         self.add_column(colname, res_data['lineage_conflict'])
-        if self.pangolin_version is None or self.pangolearn_version is None:
-            error('No pangolin/pangoLEARN versions were added before adding pangolin results.')
-        self.add_col_description(f'Lineage and the corresponding tree resolution conflict measure were determined with <a href="https://cov-lineages.org/pangolin.html">Pangolin</a> (v{self.pangolin_version} using <a href="https://cov-lineages.org/resources/pangolin/pangolearn.html">PangoLEARN</a> data release {self.pangolearn_version}).')
+        if self.pangolin_version is None or self.pangolindata_version is None:
+            error('No pangolin/pangolin-data versions were added before adding pangolin results.')
+        self.add_col_description(f'Lineage and the corresponding tree resolution conflict measure were determined with <a href="https://cov-lineages.org/pangolin.html">Pangolin</a> (v{self.pangolin_version} using <a href="https://cov-lineages.org/resources/pangolin/requirements.html">pangolin-data</a> data release {self.pangolindata_version}).')
         
         # Add scorpio info if any is present
         if res_data['scorpio_call'].notna().any():

--- a/workflows/create_summary_report.nf
+++ b/workflows/create_summary_report.nf
@@ -1,6 +1,5 @@
 include { summary_report; summary_report_fasta; summary_report_default } from './process/summary_report'
 include { plot_coverages } from '../modules/plot_coverages.nf'
-include { get_scorpio_version } from '../modules/get_scorpio_version.nf'
 include { get_variants_classification } from '../modules/get_variants_classification.nf'
 include { lcs_plot } from './process/lcs_sc2'
 
@@ -16,7 +15,6 @@ workflow create_summary_report_wf {
 
         main:
         version_ch = Channel.fromPath(workflow.projectDir + "/configs/container.config")
-        scorpio_ver_ch = get_scorpio_version()
         variants_table_ch = get_variants_classification()
 
         pangolin_results = pangolin.map {it -> it[1]}.collectFile(name: 'pangolin_results.csv', skip: 1, keepHeader: true)
@@ -27,7 +25,7 @@ workflow create_summary_report_wf {
         alignment_files = alignments.map {it -> it[0]}.collect()
         if (params.fasta || workflow.profile.contains('test_fasta')) {
             
-            summary_report_fasta(version_ch, scorpio_ver_ch, variants_table_ch, pangolin_results, president_results, nextclade_results)
+            summary_report_fasta(version_ch, variants_table_ch, pangolin_results, president_results, nextclade_results)
 
         } else {
             kraken2_results = kraken2.map {it -> it[2]}.collect()
@@ -35,8 +33,8 @@ workflow create_summary_report_wf {
             coverage_plots = plot_coverages(alignments.map{it -> it[0]}.toSortedList({ a, b -> a.simpleName <=> b.simpleName }).flatten().collate(6), \
                                             alignments.map{it -> it[1]}.toSortedList({ a, b -> a.simpleName <=> b.simpleName }).flatten().collate(6)).collect()
 
-            if (params.samples) { summary_report(version_ch, scorpio_ver_ch, variants_table_ch, pangolin_results, president_results, nextclade_results, kraken2_results, coverage_plots, samples_table) }
-            else { summary_report_default(version_ch, scorpio_ver_ch, variants_table_ch, pangolin_results, president_results, nextclade_results, kraken2_results, coverage_plots) }
+            if (params.samples) { summary_report(version_ch, variants_table_ch, pangolin_results, president_results, nextclade_results, kraken2_results, coverage_plots, samples_table) }
+            else { summary_report_default(version_ch, variants_table_ch, pangolin_results, president_results, nextclade_results, kraken2_results, coverage_plots) }
             
         }
 

--- a/workflows/process/summary_report.nf
+++ b/workflows/process/summary_report.nf
@@ -5,7 +5,6 @@ process summary_report {
     
     input:
         path(version_config)
-        tuple val(scorpio_ver), val(scorpio_constellations_ver)
         path(variants_table)
         path(pangolin_results)
         path(president_results)
@@ -32,8 +31,6 @@ process summary_report {
 
         summary_report.py \
             -v !{version_config} \
-            --scorpio_version "!{scorpio_ver}" \
-            --scorpio_constellations_version "!{scorpio_constellations_ver}" \
             --variants_table !{variants_table} \
             --porecov_version !{workflow.revision}:!{workflow.commitId}:!{workflow.scriptId} \
             --nextclade_docker !{params.nextcladedocker} \
@@ -41,7 +38,6 @@ process summary_report {
             --guppy_model !{params.guppy_model} \
             --medaka_model !{params.medaka_model} \
             --nf_commandline '!{workflow.commandLine}' \
-            --pangolin_docker !{params.pangolindocker} \
             --primer !{params.primerV} \
             -p !{pangolin_results} \
             -q !{president_results} \
@@ -63,7 +59,6 @@ process summary_report_default {
     
     input:
         path(version_config)
-        tuple val(scorpio_ver), val(scorpio_constellations_ver)
         path(variants_table)
         path(pangolin_results)
         path(president_results)
@@ -89,15 +84,12 @@ process summary_report_default {
 
         summary_report.py \
             -v !{version_config} \
-            --scorpio_version "!{scorpio_ver}" \
-            --scorpio_constellations_version "!{scorpio_constellations_ver}" \
             --variants_table !{variants_table} \
             --porecov_version !{workflow.revision}:!{workflow.commitId}:!{workflow.scriptId} \
             --guppy_used !{guppyused} \
             --guppy_model !{params.guppy_model} \
             --medaka_model !{params.medaka_model} \
             --nf_commandline '!{workflow.commandLine}' \
-            --pangolin_docker !{params.pangolindocker} \
             --nextclade_docker !{params.nextcladedocker} \
             --primer !{params.primerV} \
             -p !{pangolin_results} \
@@ -117,7 +109,6 @@ process summary_report_fasta {
         label 'fastcov'
     input:
         path(version_config)
-        tuple val(scorpio_ver), val(scorpio_constellations_ver)
         path(variants_table)
         path(pangolin_results)
         path(president_results)
@@ -131,12 +122,9 @@ process summary_report_fasta {
         """
         summary_report.py \
             -v ${version_config} \
-            --scorpio_version "${scorpio_ver}" \
-            --scorpio_constellations_version "${scorpio_constellations_ver}" \
             --variants_table ${variants_table} \
             --porecov_version ${workflow.revision}:${workflow.commitId}:${workflow.scriptId} \
             --nf_commandline '${workflow.commandLine}' \
-            --pangolin_docker ${params.pangolindocker} \
             --nextclade_docker ${params.nextcladedocker} \
             -p ${pangolin_results} \
             -q ${president_results} \


### PR DESCRIPTION
closes #220 

- uses pangolin results for getting the versions for: pangolin version, pangolin-data version, scorpio version, constellation version (instead of complicated extra inputs)
- report now appropriately writes pangolin-data instead of PangoLEARN

Cannot test for now, need the 4.0 container :)