### PR TITLE
Split LCS barplot

### DIFF
--- a/bin/lcs_bar_plot.R
+++ b/bin/lcs_bar_plot.R
@@ -14,7 +14,7 @@ input <- read.csv(tsv, sep='\t')
 
 filter(input, proportion>=proportion_cutoff) %>% ggplot(aes(x=variant_group, y=proportion)) + geom_col(position='dodge') + 
 geom_errorbar(width=0.4,aes(ymin=proportion-std_error, ymax=proportion+std_error)) + facet_wrap(~sample) +
-theme(axis.text.x=element_text(angle=90,vjust=.5)) + coord_flip() + ggsave(paste('lcs_barplot_', name, '.png'))
+theme(axis.text.x=element_text(angle=90,vjust=.5)) + coord_flip() + ggsave(paste0('lcs_barplot_', name, '.png'))
 
 # for ggplot2 versions > 3.3.0:
 # ggplot aes flip x and y

--- a/bin/lcs_bar_plot.R
+++ b/bin/lcs_bar_plot.R
@@ -6,13 +6,15 @@ library(ggplot2)
 library(dplyr)
 
 args <- commandArgs(TRUE)
-proportion_cutoff <- eval( parse(text=args[1]) )[1] 
+tsv <- args[1]
+name <- parse(text=args[2])
+proportion_cutoff <- eval( parse(text=args[3]) )
 
-input <- read.csv("lcs_results.tsv", sep='\t')
+input <- read.csv(tsv, sep='\t')
 
 filter(input, proportion>=proportion_cutoff) %>% ggplot(aes(x=variant_group, y=proportion)) + geom_col(position='dodge') + 
 geom_errorbar(width=0.4,aes(ymin=proportion-std_error, ymax=proportion+std_error)) + facet_wrap(~sample) +
-theme(axis.text.x=element_text(angle=90,vjust=.5)) + coord_flip() + ggsave("lcs_bar_plot.png")
+theme(axis.text.x=element_text(angle=90,vjust=.5)) + coord_flip() + ggsave(paste('lcs_barplot_', name, '.png'))
 
 # for ggplot2 versions > 3.3.0:
 # ggplot aes flip x and y

--- a/workflows/create_summary_report.nf
+++ b/workflows/create_summary_report.nf
@@ -2,7 +2,7 @@ include { summary_report; summary_report_fasta; summary_report_default } from '.
 include { plot_coverages } from '../modules/plot_coverages.nf'
 include { get_scorpio_version } from '../modules/get_scorpio_version.nf'
 include { get_variants_classification } from '../modules/get_variants_classification.nf'
-include { lcs_plot } from './process/lcs_sc2'
+include { lcs_plot as lcs_plot; lcs_plot as lcs_plot_control  } from './process/lcs_sc2'
 
 workflow create_summary_report_wf {
     take: 
@@ -41,7 +41,9 @@ workflow create_summary_report_wf {
         }
 
         if (params.screen_reads){
-            lcs_plot(lcs_results, params.screen_reads_plot_cutoff)
+            lcs_plot(lcs.filter({ !it[0].contains("negativ") }).map {it -> it[1]}.collectFile(name: 'lcs_results.tsv', skip: 1, keepHeader: true).map{ it -> ['samples', it] }, params.screen_reads_plot_cutoff)
+
+            lcs_plot_control(lcs.filter({ it[0].contains("negativ") }), params.screen_reads_plot_cutoff)
         }
 
 } 

--- a/workflows/process/lcs_sc2.nf
+++ b/workflows/process/lcs_sc2.nf
@@ -36,14 +36,14 @@ process lcs_plot {
   publishDir "${params.output}/${params.lineagedir}/", mode: 'copy'
 
   input:
-  path(tsv)
+  tuple val(name), path(tsv)
   val(cutoff)
   
   output:
-  path("lcs_bar_plot.png")
+  path("*.png")
   
   script:
   """
-  lcs_bar_plot.R ${cutoff}
+  lcs_bar_plot.R '${tsv}' '${name}' ${cutoff}
   """
 }


### PR DESCRIPTION
The barplot is now split into a single one for the control sample and the rest.
A lot of variants seem to be detected in the control, which messes up the readability for the rest.