### PR TITLE
LCS UCSC marker update feature

### DIFF
--- a/bin/lcs_bar_plot.R
+++ b/bin/lcs_bar_plot.R
@@ -7,14 +7,18 @@ library(dplyr)
 
 args <- commandArgs(TRUE)
 tsv <- args[1]
-name <- parse(text=args[2])
-proportion_cutoff <- eval( parse(text=args[3]) )
+# name <- parse(text=args[2])
+proportion_cutoff <- eval( parse(text=args[2]) )
 
 input <- read.csv(tsv, sep='\t')
 
 filter(input, proportion>=proportion_cutoff) %>% ggplot(aes(x=variant_group, y=proportion)) + geom_col(position='dodge') + 
-geom_errorbar(width=0.4,aes(ymin=proportion-std_error, ymax=proportion+std_error)) + facet_wrap(~sample) +
-theme(axis.text.x=element_text(angle=90,vjust=.5)) + coord_flip() + ggsave(paste0('lcs_barplot_', name, '.png'))
+geom_errorbar(width=0.4,aes(ymin=proportion-std_error, ymax=proportion+std_error)) + 
+facet_grid(sample ~ ., scales = "free", space = "free") +
+theme(strip.text.y = element_text(angle = 0)) +
+# facet_wrap(~sample, scales = "free_y", ncol=1) +
+theme(axis.text.x=element_text(angle=90,vjust=.5)) + coord_flip() 
+ggsave(paste0('lcs_barplot', '.png'), height=14)
 
 # for ggplot2 versions > 3.3.0:
 # ggplot aes flip x and y

--- a/configs/container.config
+++ b/configs/container.config
@@ -10,7 +10,7 @@ process {
     withLabel:  ggplot2     { container = 'nanozoo/r_ggpubr:0.2.5--4b52011' }
     withLabel:  kraken2     { container = 'nanozoo/kraken2:2.1.1--d5ded30'}
     withLabel:  krona       { container = 'nanozoo/krona:2.7.1--e7615f7'}
-    withLabel:  lcs_sc2     { container = 'nanozoo/lcs_sc2:1.1.0--15efca6'}
+    withLabel:  lcs_sc2     { container = 'nanozoo/lcs_sc2:1.1.0--3741450'}
     withLabel:  minimap2    { container = 'nanozoo/minimap2:2.17--7066fef' }
     withLabel:  nanoplot    { container = 'nanozoo/nanoplot:1.32.0--1ae6f5d' }
     withLabel:  president   { container = 'rkibioinf/president:v0.6.3' }

--- a/configs/nodes.config
+++ b/configs/nodes.config
@@ -9,7 +9,7 @@ process {
     withLabel:  guppy_cpu   { cpus = 60; memory = '60 GB' }
     withLabel:  guppy_gpu   { cpus = 10; memory = '16 GB' }
     withLabel:  kraken2     { cpus = 20; memory = '60 GB' }
-    withLabel:  lcs_sc2     { cpus = 12; memory = '12 GB' }
+    withLabel:  lcs_sc2     { cpus = 10; memory = '60 GB' }
     withLabel:  krona       { cpus = 2; memory = '2 GB' }
     withLabel:  minimap2    { cpus = 12; memory = '12 GB' }
     withLabel:  nanoplot    { cpus = 8; memory = '8 GB' }

--- a/nextflow.config
+++ b/nextflow.config
@@ -41,7 +41,7 @@ params {
     update = false
     screen_reads = false
     lcs_ucsc_version = 'predefined' // e.g. '2022-05-01' marker-table date
-    lcs_ucsc_predefined = '2022-01-31'
+    lcs_ucsc_predefined = '2022-05-15'
     lcs_ucsc_update = false // update marker table, overrides lcs_ucsc_version
     lcs_ucsc_downsampling = 10000 // 'None' to turn off
     lcs_variant_groups = 'default' // 'default' to use file from repo; custom variant groups table for marker-table update

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,7 +45,7 @@ params {
     lcs_ucsc_update = false // update marker table, overrides lcs_ucsc_version
     lcs_ucsc_downsampling = 10000 // 'None' to turn off
     lcs_variant_groups = 'default' // 'default' to use file from repo; custom variant groups table for marker-table update
-    screen_reads_plot_cutoff = 0.03
+    lcs_cutoff = 0.03
     defaultpangolin = 'nanozoo/pangolin-v4:4.0.4--1.2.133'
     defaultnextclade = 'nanozoo/nextclade:1.11.0--2022-03-31'
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -40,6 +40,10 @@ params {
     single = false
     update = false
     screen_reads = false
+    lcs_ucsc_default = 'predefined' // e.g. '2022-05-01' marker-table date
+    lcs_ucsc_update = false // update marker table, overrides lcs_ucsc_default
+    lcs_ucsc_downsampling = 10000 // 'None' to turn off
+    lcs_variant_groups = 'default' // 'default' to use file from repo; custom variant groups table for marker-table update
     screen_reads_plot_cutoff = 0.03
     defaultpangolin = 'nanozoo/pangolin-v4:4.0.4--1.2.133'
     defaultnextclade = 'nanozoo/nextclade:1.11.0--2022-03-31'

--- a/nextflow.config
+++ b/nextflow.config
@@ -40,8 +40,9 @@ params {
     single = false
     update = false
     screen_reads = false
-    lcs_ucsc_default = 'predefined' // e.g. '2022-05-01' marker-table date
-    lcs_ucsc_update = false // update marker table, overrides lcs_ucsc_default
+    lcs_ucsc_version = 'predefined' // e.g. '2022-05-01' marker-table date
+    lcs_ucsc_predefined = '2022-01-31'
+    lcs_ucsc_update = false // update marker table, overrides lcs_ucsc_version
     lcs_ucsc_downsampling = 10000 // 'None' to turn off
     lcs_variant_groups = 'default' // 'default' to use file from repo; custom variant groups table for marker-table update
     screen_reads_plot_cutoff = 0.03

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -487,8 +487,8 @@ ${c_yellow}Parameters - Lineage detection on reads (see screen_reads, optional)$
     --lcs_ucsc_downsampling  Downsample sequences when updating marker table to save resources. Use 'None' to turn off [default: $params.lcs_ucsc_downsampling]
                                  ${c_dim}Attention! Updating without downsampling needs a lot of resources in terms of memory and might fail.
                                  Consider downsampling or increase the memory for this process.${c_reset}
-    --lcs_variant_groups     Provide path to custom variant groups table (TSV) for marker table update. Use 'default' for predefined groups from repo
-                                 (https://github.com/rki-mf1/LCS/blob/master/data/variant_groups.tsv) [default: $params.lcs_variant_groups]
+    --lcs_variant_groups     Provide path to custom variant groups table (TSV) for marker table update (requires --lcs_ucsc_update). Use 'default' 
+                                 for predefined groups from repo (https://github.com/rki-mf1/LCS/blob/master/data/variant_groups.tsv) [default: $params.lcs_variant_groups]
     --lcs_cutoff             Plot linages above this threshold [default: $params.lcs_cutoff]     
 
 ${c_yellow}Parameters - Basecalling  (optional)${c_reset}

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -453,17 +453,28 @@ ${c_yellow}Inputs (choose one):${c_reset}
                     ${c_dim}[Lineage + Reports]${c_reset}
 
 ${c_yellow}Workflow control (optional)${c_reset}
-    --update        Always try to use latest pangolin & nextclade release [default: $params.update]
-    --samples       .csv input (header: Status,_id), renames barcodes (Status) by name (_id), e.g.:
-                    Status,_id
-                    barcode01,sample2011XY
-                    BC02,thirdsample_run
-    --extended      poreCov utilizes from --samples these additional headers:
-                    Submitting_Lab,Isolation_Date,Seq_Reason,Sample_Type
-    --nanopolish    use nanopolish instead of medaka for ARTIC (needs --fast5)
-                    to skip basecalling use --fastq or --fastq_pass and provide a sequencing_summary.txt in addition to --fast5
-                    e.g --nanopolish sequencing_summary.txt
-    --screen_reads  Determines the Pangolineage of each individual read (takes time)         
+    --update                 Always try to use latest pangolin & nextclade release [default: $params.update]
+    --samples                .csv input (header: Status,_id), renames barcodes (Status) by name (_id), e.g.:
+                             Status,_id
+                             barcode01,sample2011XY
+                             BC02,thirdsample_run
+    --extended               poreCov utilizes from --samples these additional headers:
+                             Submitting_Lab,Isolation_Date,Seq_Reason,Sample_Type
+    --nanopolish             use nanopolish instead of medaka for ARTIC (needs --fast5)
+                             to skip basecalling use --fastq or --fastq_pass and provide a sequencing_summary.txt in addition to --fast5
+                             e.g --nanopolish sequencing_summary.txt
+    --screen_reads           Determines the Pangolineage of each individual read (takes time)    
+    --lcs_ucsc_default       Create marker table based on a specific UCSC SARS-CoV-2 tree (e.g. '2022-05-01'). Use 'predefined' 
+                             to use the marker table from the repo (most probably not up-to-date) [default: $params.lcs_ucsc_default]
+                                 ${c_dim}See https://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2 for available trees.${c_reset}
+    --lcs_ucsc_update        Use latest UCSC SARS-CoV-2 tree for marker table update. Overwrites --lcs_ucsc_default [default: $params.lcs_ucsc_update]
+                                 ${c_dim}Automatically checks https://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/public-latest.version.txt${c_reset}
+    --lcs_ucsc_downsampling  Downsample sequences when updating marker table to save resources. Use 'None' to turn off [default: $params.lcs_ucsc_downsampling]
+                                 ${c_dim}Attention! Updating without downsampling needs a lot of resources in terms of memory and might fail.
+                                 Consider downsampling or increase the memory for this process.${c_reset}
+    --lcs_variant_groups     Provide path to custom variant groups table (TSV) for marker table update. Use 'default' for predefined groups from repo
+                                 (https://github.com/rki-mf1/LCS/blob/master/data/variant_groups.tsv) [default: $params.lcs_variant_groups]
+    --lcs_cutoff             Plot linages above this threshold [default: $params.lcs_cutoff]     
 
 ${c_yellow}Parameters - Basecalling  (optional)${c_reset}
     --localguppy    use a native installation of guppy instead of a gpu-docker or gpu_singularity 

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -277,10 +277,10 @@ if ( params.screen_reads && params.lcs_ucsc_update ){
         params.lcs_ucsc = latest_version
     }
     if ( internetcheck.toString() == "false" ) { 
-        println "\033[0;33mCould not find the latest UCSC version, trying: " + params.lcs_ucsc_default + "\033[0m"
-        params.lcs_ucsc = params.lcs_ucsc_default
+        println "\033[0;33mCould not find the latest UCSC version, trying: " + params.lcs_ucsc_version + "\033[0m"
+        params.lcs_ucsc = params.lcs_ucsc_version
     }
-} else { params.lcs_ucsc = params.lcs_ucsc_default}
+} else { params.lcs_ucsc = params.lcs_ucsc_version}
 
 
 /************************** 
@@ -477,10 +477,10 @@ ${c_yellow}Workflow control (optional)${c_reset}
                              to skip basecalling use --fastq or --fastq_pass and provide a sequencing_summary.txt in addition to --fast5
                              e.g --nanopolish sequencing_summary.txt
     --screen_reads           Determines the Pangolineage of each individual read (takes time)    
-    --lcs_ucsc_default       Create marker table based on a specific UCSC SARS-CoV-2 tree (e.g. '2022-05-01'). Use 'predefined' 
-                             to use the marker table from the repo (most probably not up-to-date) [default: $params.lcs_ucsc_default]
+    --lcs_ucsc_version       Create marker table based on a specific UCSC SARS-CoV-2 tree (e.g. '2022-05-01'). Use 'predefined' 
+                             to use the marker table from the repo (most probably not up-to-date) [default: $params.lcs_ucsc_version]
                                  ${c_dim}See https://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2 for available trees.${c_reset}
-    --lcs_ucsc_update        Use latest UCSC SARS-CoV-2 tree for marker table update. Overwrites --lcs_ucsc_default [default: $params.lcs_ucsc_update]
+    --lcs_ucsc_update        Use latest UCSC SARS-CoV-2 tree for marker table update. Overwrites --lcs_ucsc_version [default: $params.lcs_ucsc_update]
                                  ${c_dim}Automatically checks https://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/public-latest.version.txt${c_reset}
     --lcs_ucsc_downsampling  Downsample sequences when updating marker table to save resources. Use 'None' to turn off [default: $params.lcs_ucsc_downsampling]
                                  ${c_dim}Attention! Updating without downsampling needs a lot of resources in terms of memory and might fail.

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -270,6 +270,19 @@ println "\033[0;33mWarning: Running --update might not be poreCov compatible!\03
 }
 else { params.pangolindocker = params.defaultpangolin ; params.nextcladedocker = params.defaultnextclade  }
 
+if ( params.screen_reads && params.lcs_ucsc_update ){
+    if ( internetcheck.toString() == "true" ) { 
+        latest_version = 'https://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/public-latest.version.txt'.toURL().text.split('\\(')[1].split('\\)')[0]
+        println "\033[0;32mFound latest UCSC version, using: " + latest_version + " \033[0m" 
+        params.lcs_ucsc = latest_version
+    }
+    if ( internetcheck.toString() == "false" ) { 
+        println "\033[0;33mCould not find the latest UCSC version, trying: " + params.lcs_ucsc_default + "\033[0m"
+        params.lcs_ucsc = params.lcs_ucsc_default
+    }
+} else { params.lcs_ucsc = params.lcs_ucsc_default}
+
+
 /************************** 
 * Log-infos
 **************************/

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -476,7 +476,9 @@ ${c_yellow}Workflow control (optional)${c_reset}
     --nanopolish             use nanopolish instead of medaka for ARTIC (needs --fast5)
                              to skip basecalling use --fastq or --fastq_pass and provide a sequencing_summary.txt in addition to --fast5
                              e.g --nanopolish sequencing_summary.txt
-    --screen_reads           Determines the Pangolineage of each individual read (takes time)    
+    --screen_reads           Determines the Pangolineage of each individual read (takes time)   
+
+${c_yellow}Parameters - Lineage detection on reads (see screen_reads, optional)${c_reset}
     --lcs_ucsc_version       Create marker table based on a specific UCSC SARS-CoV-2 tree (e.g. '2022-05-01'). Use 'predefined' 
                              to use the marker table from the repo (most probably not up-to-date) [default: $params.lcs_ucsc_version]
                                  ${c_dim}See https://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2 for available trees.${c_reset}

--- a/workflows/create_summary_report.nf
+++ b/workflows/create_summary_report.nf
@@ -1,7 +1,7 @@
 include { summary_report; summary_report_fasta; summary_report_default } from './process/summary_report'
 include { plot_coverages } from '../modules/plot_coverages.nf'
 include { get_variants_classification } from '../modules/get_variants_classification.nf'
-include { lcs_plot as lcs_plot; lcs_plot as lcs_plot_control  } from './process/lcs_sc2'
+include { lcs_plot } from './process/lcs_sc2'
 
 workflow create_summary_report_wf {
     take: 
@@ -39,9 +39,7 @@ workflow create_summary_report_wf {
         }
 
         if (params.screen_reads){
-            lcs_plot(lcs.filter({ !it[0].contains("negativ") }).map {it -> it[1]}.collectFile(name: 'lcs_results.tsv', skip: 1, keepHeader: true).map{ it -> ['samples', it] }, params.screen_reads_plot_cutoff)
-
-            lcs_plot_control(lcs.filter({ it[0].contains("negativ") }), params.screen_reads_plot_cutoff)
+            lcs_plot(lcs.map {it -> it[1]}.collectFile(name: 'lcs_results.tsv', skip: 1, keepHeader: true), params.screen_reads_plot_cutoff)
         }
 
 } 

--- a/workflows/create_summary_report.nf
+++ b/workflows/create_summary_report.nf
@@ -39,7 +39,7 @@ workflow create_summary_report_wf {
         }
 
         if (params.screen_reads){
-            lcs_plot(lcs.map {it -> it[1]}.collectFile(name: 'lcs_results.tsv', skip: 1, keepHeader: true), params.screen_reads_plot_cutoff)
+            lcs_plot(lcs.map {it -> it[1]}.collectFile(name: 'lcs_results.tsv', skip: 1, keepHeader: true), params.lcs_cutoff)
         }
 
 } 

--- a/workflows/process/lcs_sc2.nf
+++ b/workflows/process/lcs_sc2.nf
@@ -31,7 +31,7 @@ process lcs_ucsc_markers_table {
         """
         git clone https://github.com/rki-mf1/LCS.git
         mkdir -p LCS/outputs/variants_table
-        zcat LCS/data/pre-generated-marker-tables/ucsc-markers-2022-01-31.tsv.gz > LCS/outputs/variants_table/ucsc-markers-table.tsv
+        zcat LCS/data/pre-generated-marker-tables/ucsc-markers-${params.lcs_ucsc_predefined}.tsv.gz > LCS/outputs/variants_table/ucsc-markers-table.tsv
         mv LCS/outputs/variants_table/ucsc-markers-table.tsv LCS/outputs/variants_table/ucsc-markers-table-predefined.tsv 
         """
     stub:

--- a/workflows/process/lcs_sc2.nf
+++ b/workflows/process/lcs_sc2.nf
@@ -1,8 +1,50 @@
+process lcs_ucsc_markers_table {
+    label 'lcs_sc2'
+
+    input:
+    path(variant_group_tsv)
+
+    output:
+    path("LCS/outputs/variants_table/ucsc-markers-table-*.tsv")
+
+    script:
+    if ( params.lcs_ucsc_update || params.lcs_ucsc_default != 'predefined')
+        """
+        git clone https://github.com/rki-mf1/LCS.git
+
+        if [[ "${variant_group_tsv}" != default ]]; then
+            rm -rf LCS/data/variant_groups.tsv
+            cp ${variant_group_tsv} LCS/data/variant_groups.tsv
+        fi
+
+        cd LCS
+        ## change settings
+        sed -i "s/PB_VERSION=.*/PB_VERSION='${params.lcs_ucsc}'/" rules/config.py
+        sed -i "s/NUM_SAMPLE=.*/NUM_SAMPLE=${params.lcs_ucsc_downsampling}/" rules/config.py
+        mem=\$(echo ${task.memory} | cut -d' ' -f1)
+        ## run pipeline
+        snakemake --cores ${task.cpus} --resources mem_gb=\$mem --config dataset=somestring markers=ucsc -- ucsc_gather_tables
+        ## output
+        mv outputs/variants_table/ucsc-markers-table.tsv outputs/variants_table/ucsc-markers-table-${params.lcs_ucsc}.tsv 
+        """
+    else if ( params.lcs_ucsc_default == 'predefined' )
+        """
+        git clone https://github.com/rki-mf1/LCS.git
+        mkdir -p LCS/outputs/variants_table
+        zcat LCS/data/pre-generated-marker-tables/ucsc-markers-2022-01-31.tsv.gz > LCS/outputs/variants_table/ucsc-markers-table.tsv
+        mv LCS/outputs/variants_table/ucsc-markers-table.tsv LCS/outputs/variants_table/ucsc-markers-table-predefined.tsv 
+        """
+    stub:
+    """
+    touch LCS/outputs/variants_table/ucsc-markers-table-42.tsv
+    """
+}
+
 process lcs_sc2 {
     label 'lcs_sc2'
     publishDir "${params.output}/${params.lineagedir}/${name}/lineage-proportion-by-reads", mode: 'copy'
     input:
-        tuple val(name), path(reads)
+      tuple val(name), path(reads), path(ucsc_markers_table)
   	output:
     	tuple val(name), path("${name}.lcs.tsv")
   	script:
@@ -10,8 +52,7 @@ process lcs_sc2 {
     git clone https://github.com/rvalieris/LCS.git
 
     mkdir -p LCS/outputs/variants_table
-    zcat LCS/data/pre-generated-marker-tables/pango-designation-markers-v1.2.124.tsv.gz > LCS/outputs/variants_table/pango-markers-table.tsv
-    zcat LCS/data/pre-generated-marker-tables/ucsc-markers-2022-01-31.tsv.gz > LCS/outputs/variants_table/ucsc-markers-table.tsv
+    mv ${ucsc_markers_table} LCS/outputs/variants_table/ucsc-markers-table.tsv  
 
     mkdir -p LCS/data/fastq
     cp ${reads} LCS/data/fastq/
@@ -24,6 +65,7 @@ process lcs_sc2 {
     cd ..
 
     cp LCS/outputs/decompose/mypool.out ${name}.lcs.tsv
+    rm -rf LCS/data/fastq
     """
     stub:
     """
@@ -36,7 +78,7 @@ process lcs_plot {
   publishDir "${params.output}/${params.lineagedir}/", mode: 'copy'
 
   input:
-  tuple val(name), path(tsv)
+  path(tsv)
   val(cutoff)
   
   output:
@@ -44,6 +86,6 @@ process lcs_plot {
   
   script:
   """
-  lcs_bar_plot.R '${tsv}' '${name}' ${cutoff}
+  lcs_bar_plot.R '${tsv}' ${cutoff}
   """
 }

--- a/workflows/process/lcs_sc2.nf
+++ b/workflows/process/lcs_sc2.nf
@@ -8,7 +8,7 @@ process lcs_ucsc_markers_table {
     path("LCS/outputs/variants_table/ucsc-markers-table-*.tsv")
 
     script:
-    if ( params.lcs_ucsc_update || params.lcs_ucsc_default != 'predefined')
+    if ( params.lcs_ucsc_update || params.lcs_ucsc_version != 'predefined')
         """
         git clone https://github.com/rki-mf1/LCS.git
 
@@ -27,7 +27,7 @@ process lcs_ucsc_markers_table {
         ## output
         mv outputs/variants_table/ucsc-markers-table.tsv outputs/variants_table/ucsc-markers-table-${params.lcs_ucsc}.tsv 
         """
-    else if ( params.lcs_ucsc_default == 'predefined' )
+    else if ( params.lcs_ucsc_version == 'predefined' )
         """
         git clone https://github.com/rki-mf1/LCS.git
         mkdir -p LCS/outputs/variants_table

--- a/workflows/process/lcs_sc2.nf
+++ b/workflows/process/lcs_sc2.nf
@@ -50,7 +50,7 @@ process lcs_sc2 {
     tuple val(name), path("${name}.lcs.tsv")
   	script:
     """
-    git clone https://github.com/rvalieris/LCS.git
+    git clone https://github.com/rki-mf1/LCS.git
 
     mkdir -p LCS/outputs/variants_table
     mv ${ucsc_markers_table} LCS/outputs/variants_table/ucsc-markers-table.tsv  

--- a/workflows/process/lcs_sc2.nf
+++ b/workflows/process/lcs_sc2.nf
@@ -36,6 +36,7 @@ process lcs_ucsc_markers_table {
         """
     stub:
     """
+    mkdir -p LCS/outputs/variants_table/
     touch LCS/outputs/variants_table/ucsc-markers-table-42.tsv
     """
 }
@@ -44,9 +45,9 @@ process lcs_sc2 {
     label 'lcs_sc2'
     publishDir "${params.output}/${params.lineagedir}/${name}/lineage-proportion-by-reads", mode: 'copy'
     input:
-      tuple val(name), path(reads), path(ucsc_markers_table)
+    tuple val(name), path(reads), path(ucsc_markers_table)
   	output:
-    	tuple val(name), path("${name}.lcs.tsv")
+    tuple val(name), path("${name}.lcs.tsv")
   	script:
     """
     git clone https://github.com/rvalieris/LCS.git

--- a/workflows/read_classification.nf
+++ b/workflows/read_classification.nf
@@ -1,7 +1,7 @@
 include { kraken2 } from './process/kraken2.nf' 
 include { krona } from './process/krona.nf' 
 include { download_database_kraken2 } from './process/download_database_kraken2.nf'
-include { lcs_sc2 } from './process/lcs_sc2' 
+include { lcs_sc2; lcs_ucsc_markers_table } from './process/lcs_sc2' 
 
 workflow read_classification_wf {
     take:   
@@ -20,7 +20,8 @@ workflow read_classification_wf {
 
         // calculate mixed/ pooled samples using LCS, https://github.com/rvalieris/LCS
         if (params.screen_reads) {
-            lcs_sc2(fastq)
+            lcs_ucsc_markers_table( params.lcs_variant_groups == 'default' ? file('default') : Channel.fromPath("${params.lcs_variant_groups}", checkIfExists: true) )
+            lcs_sc2(fastq.combine(lcs_ucsc_markers_table.out))
             lcs_output = lcs_sc2.out
         } else {
             lcs_output = Channel.empty()

--- a/workflows/read_classification.nf
+++ b/workflows/read_classification.nf
@@ -20,7 +20,12 @@ workflow read_classification_wf {
 
         // calculate mixed/ pooled samples using LCS, https://github.com/rvalieris/LCS
         if (params.screen_reads) {
-            lcs_ucsc_markers_table( params.lcs_variant_groups == 'default' ? file('default') : Channel.fromPath("${params.lcs_variant_groups}", checkIfExists: true) )
+            if (params.lcs_variant_groups == 'default'){
+                lcs_variant_groups_ch = Channel.empty()
+            } else {
+                lcs_variant_groups_ch = Channel.fromPath("${params.lcs_variant_groups}", checkIfExists: true) 
+            }
+            lcs_ucsc_markers_table(lcs_variant_groups_ch.ifEmpty([]))
             lcs_sc2(fastq.combine(lcs_ucsc_markers_table.out))
             lcs_output = lcs_sc2.out
         } else {


### PR DESCRIPTION
Adds the functionality to generate an updated UCSC marker table via:
```
--lcs_ucsc_version       Create marker table based on a specific UCSC SARS-CoV-2 tree (e.g. '2022-05-01'). Use 'predefined' 
                             to use the marker table from the repo (most probably not up-to-date) [default: predefined]
                                See https://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2 for available trees.
--lcs_ucsc_predefined    If '--lcs_ucsc_version 'predefined'', select pre-calculated UCSC table [default: 2022-01-31]
                                 See https://github.com/rki-mf1/LCS/tree/master/data/pre-generated-marker-tables
--lcs_ucsc_update        Use latest UCSC SARS-CoV-2 tree for marker table update. Overwrites --lcs_ucsc_version [default: false]
                                 Automatically checks https://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/public-latest.version.txt
--lcs_ucsc_downsampling  Downsample sequences when updating marker table to save resources. Use 'None' to turn off [default: 10000]
                                 Attention! Updating without downsampling needs a lot of resources in terms of memory and might fail.
                                 Consider downsampling or increase the memory for this process.
--lcs_variant_groups     Provide path to custom variant groups table (TSV) for marker table update. Use 'default' for predefined groups from repo
                                 (https://github.com/rki-mf1/LCS/blob/master/data/variant_groups.tsv) [default: default]
```

Waits for nanozoo LCS container with updated `usher` version