### PR TITLE
added skip-scorpio parameter fixes #234

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -48,7 +48,7 @@ params {
     lcs_cutoff = 0.03
     defaultpangolin = 'nanozoo/pangolin-v4:4.0.4--1.2.133'
     defaultnextclade = 'nanozoo/nextclade:1.11.0--2022-03-31'
-    pangolin_skip_scorpio = true
+    scorpio = false
 
     // parameters
     primerV = 'V3'

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,7 +48,7 @@ params {
     lcs_cutoff = 0.03
     defaultpangolin = 'nanozoo/pangolin-v4:4.0.4--1.2.133'
     defaultnextclade = 'nanozoo/nextclade:1.11.0--2022-03-31'
-    pangolin_skip_scorpio = false
+    pangolin_skip_scorpio = true
 
     // parameters
     primerV = 'V3'

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,6 +48,7 @@ params {
     lcs_cutoff = 0.03
     defaultpangolin = 'nanozoo/pangolin-v4:4.0.4--1.2.133'
     defaultnextclade = 'nanozoo/nextclade:1.11.0--2022-03-31'
+    pangolin_skip_scorpio = false
 
     // parameters
     primerV = 'V3'

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -476,7 +476,9 @@ ${c_yellow}Workflow control (optional)${c_reset}
     --nanopolish             use nanopolish instead of medaka for ARTIC (needs --fast5)
                              to skip basecalling use --fastq or --fastq_pass and provide a sequencing_summary.txt in addition to --fast5
                              e.g --nanopolish sequencing_summary.txt
-    --screen_reads           Determines the Pangolineage of each individual read (takes time)   
+    --screen_reads           Determines the Pangolineage of each individual read (takes time)
+    --pangolin_skip_scorpio  Skip Scorpio in pangolin run [default: $params.pangolin_skip_scorpio]
+                                  ${c_dim}From pangolin version 4, Scorpio overwrites Usher results which leads to many unassigned samples${c_reset}
 
 ${c_yellow}Parameters - Lineage detection on reads (see screen_reads, optional)${c_reset}
     --lcs_ucsc_version       Create marker table based on a specific UCSC SARS-CoV-2 tree (e.g. '2022-05-01'). Use 'predefined' 

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -478,7 +478,8 @@ ${c_yellow}Workflow control (optional)${c_reset}
                              e.g --nanopolish sequencing_summary.txt
     --screen_reads           Determines the Pangolineage of each individual read (takes time)
     --pangolin_skip_scorpio  Skip Scorpio in pangolin run [default: $params.pangolin_skip_scorpio]
-                                  ${c_dim}From pangolin version 4, Scorpio overwrites Usher results which leads to many unassigned samples${c_reset}
+                                  ${c_dim}From pangolin version 4, Scorpio overwrites Usher results which leads to many unassigned samples
+                                  Can be turned of with --pangolin_skip_scorpio false${c_reset}
 
 ${c_yellow}Parameters - Lineage detection on reads (see screen_reads, optional)${c_reset}
     --lcs_ucsc_version       Create marker table based on a specific UCSC SARS-CoV-2 tree (e.g. '2022-05-01'). Use 'predefined' 

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -477,9 +477,9 @@ ${c_yellow}Workflow control (optional)${c_reset}
                              to skip basecalling use --fastq or --fastq_pass and provide a sequencing_summary.txt in addition to --fast5
                              e.g --nanopolish sequencing_summary.txt
     --screen_reads           Determines the Pangolineage of each individual read (takes time)
-    --pangolin_skip_scorpio  Skip Scorpio in pangolin run [default: $params.pangolin_skip_scorpio]
+    --scorpio  Skip Scorpio in pangolin run [default: $params.scorpio]
                                   ${c_dim}From pangolin version 4, Scorpio overwrites Usher results which leads to many unassigned samples
-                                  Can be turned of with --pangolin_skip_scorpio false${c_reset}
+                                  Can be turned on with --scorpio${c_reset}
 
 ${c_yellow}Parameters - Lineage detection on reads (see screen_reads, optional)${c_reset}
     --lcs_ucsc_version       Create marker table based on a specific UCSC SARS-CoV-2 tree (e.g. '2022-05-01'). Use 'predefined' 

--- a/workflows/process/pangolin.nf
+++ b/workflows/process/pangolin.nf
@@ -7,7 +7,7 @@ process pangolin {
   output:
     tuple val(name), path("lineage_report_${name}.csv") optional true
   script:
-    def args = params.pangolin_skip_scorpio ? '--skip-scorpio' : ''
+    def args = params.scorpio ? '' : '--skip-scorpio'
     """
     pangolin ${args} -t ${task.cpus} ${fasta}
 

--- a/workflows/process/pangolin.nf
+++ b/workflows/process/pangolin.nf
@@ -7,8 +7,9 @@ process pangolin {
   output:
     tuple val(name), path("lineage_report_${name}.csv") optional true
   script:
+    def args = params.pangolin_skip_scorpio ? '--skip-scorpio' : ''
     """
-    pangolin -t ${task.cpus} ${fasta}
+    pangolin ${args} -t ${task.cpus} ${fasta}
 
     mv lineage_report.csv lineage_report_${name}.csv
     


### PR DESCRIPTION
- for now the default is that `scorpio` is not skipped and can be skipped with `pangolin_skip_scorpio`