### PR TITLE
Split fasta improvement

### DIFF
--- a/bin/split_fasta.py
+++ b/bin/split_fasta.py
@@ -36,11 +36,11 @@ for fasta_file in sys.argv[1:]:
         if line.startswith('>'):
 
             # new sequence
-            seq_name = line.strip().split()[0][1:]
+            seq_name = line.strip()[1:]
             assert seq_name != '', f'Empty header in file: {fasta_file}'
             
             # sanitize
-            seq_name = seq_name.replace('/', '_').replace(':', '_').replace('|','_')
+            seq_name = seq_name.replace(' ', '_').replace('/', '_').replace(':', '_').replace('|','_')
 
             # handle duplicates
             if seq_name in sequence_names:

--- a/bin/split_fasta.py
+++ b/bin/split_fasta.py
@@ -59,7 +59,10 @@ for fasta_file in sys.argv[1:]:
             log(f'Writing {outfile}')
             outfh = open(outfile, 'w')
             outfh.write(f'>{seq_name}\n')
-            
+
+        elif line in ['\n','\r\n']:
+            continue
+
         else:
             # write rest of lines (and fix windows line endings)
             outfh.write(line.replace('\r',''))


### PR DESCRIPTION
Changes to split_fasta.py in the fasta-input:

1. Fixed the issue with leading empty lines in the fasta-file causing an error that fails the whole pipeline -> now empty-lines are skipped completely
2. Changed behaviour regarding the fasta-header:
- Before the header was split when a whitespace occured and only the first part wastaken as the new fasta-header -> this could lead to problems with fastas from e.g. GISAID that included whitespaces in their name (like "hcov19/Hong Kong/...") and were therefore detected as duplicates of the same sequence even if it were different sequences.
- Now whitespaces are replaced with "_" -> can lead to longer file-names & fasta-headers, but the whole header information is preserved