### PR TITLE
bumped predefined LCS table to 2023-01-26

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -41,7 +41,7 @@ params {
     update = false
     screen_reads = false
     lcs_ucsc_version = 'predefined' // e.g. '2022-05-01' marker-table date
-    lcs_ucsc_predefined = '2022-05-15'
+    lcs_ucsc_predefined = '2023-01-26'
     lcs_ucsc_update = false // update marker table, overrides lcs_ucsc_version
     lcs_ucsc_downsampling = 10000 // 'None' to turn off
     lcs_variant_groups = 'default' // 'default' to use file from repo; custom variant groups table for marker-table update

--- a/workflows/process/lcs_sc2.nf
+++ b/workflows/process/lcs_sc2.nf
@@ -10,7 +10,7 @@ process lcs_ucsc_markers_table {
     script:
     if ( params.lcs_ucsc_update || params.lcs_ucsc_version != 'predefined')
         """
-        git clone https://github.com/rki-mf1/LCS.git
+        git clone https://github.com/rki-mf1/LCS.git --branch 2023.01.30
 
         if [[ "${variant_group_tsv}" != default ]]; then
             rm -rf LCS/data/variant_groups.tsv
@@ -29,7 +29,7 @@ process lcs_ucsc_markers_table {
         """
     else if ( params.lcs_ucsc_version == 'predefined' )
         """
-        git clone https://github.com/rki-mf1/LCS.git
+        git clone https://github.com/rki-mf1/LCS.git --branch 2023.01.30
         mkdir -p LCS/outputs/variants_table
         zcat LCS/data/pre-generated-marker-tables/ucsc-markers-${params.lcs_ucsc_predefined}.tsv.gz > LCS/outputs/variants_table/ucsc-markers-table.tsv
         mv LCS/outputs/variants_table/ucsc-markers-table.tsv LCS/outputs/variants_table/ucsc-markers-table-predefined.tsv 
@@ -50,7 +50,7 @@ process lcs_sc2 {
     tuple val(name), path("${name}.lcs.tsv")
   	script:
     """
-    git clone https://github.com/rki-mf1/LCS.git
+    git clone https://github.com/rki-mf1/LCS.git --branch 2023.01.30
 
     mkdir -p LCS/outputs/variants_table
     mv ${ucsc_markers_table} LCS/outputs/variants_table/ucsc-markers-table.tsv  


### PR DESCRIPTION
- bumped predefined LCS table to 2023-01-26
- introduced tags for LCS repo cloning