### PR TITLE
[Enhancment] publish more logs/intermediate files from ARTIC

### DIFF
--- a/workflows/process/artic.nf
+++ b/workflows/process/artic.nf
@@ -4,6 +4,8 @@ process artic_medaka {
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}_mapped_*.primertrimmed.sorted.bam*"
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.trimmed.rg.sorted.bam"
         publishDir "${params.output}/${params.genomedir}/all_consensus_sequences/", mode: 'copy', pattern: "*.consensus.fasta"
+        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.vcfcheck.log"
+        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.primersitereport.txt"
         publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "SNP_${name}.pass.vcf"
 
     input:
@@ -49,7 +51,9 @@ process artic_medaka {
             ${name}.pass.vcf.gz \
             ${name}.coverage_mask.txt.nCoV-2019_1.depths \
             ${name}.coverage_mask.txt.nCoV-2019_2.depths \
-            ${name}.trimmed.rg.sorted.bam
+            ${name}.trimmed.rg.sorted.bam \
+            ${name}.vcfcheck.log \
+            ${name}.primersitereport.txt
         """
 }
 
@@ -59,6 +63,8 @@ process artic_medaka_custom_bed {
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}_mapped_*.primertrimmed.sorted.bam*"
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.trimmed.rg.sorted.bam"
         publishDir "${params.output}/${params.genomedir}/all_consensus_sequences/", mode: 'copy', pattern: "*.consensus.fasta"
+        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.vcfcheck.log"
+        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.primersitereport.txt"
         publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "SNP_${name}.pass.vcf"
 
     input:
@@ -115,7 +121,9 @@ process artic_medaka_custom_bed {
             ${name}.pass.vcf.gz \
             ${name}.coverage_mask.txt.nCoV-2019_1.depths \
             ${name}.coverage_mask.txt.nCoV-2019_2.depths \
-            ${name}.trimmed.rg.sorted.bam
+            ${name}.trimmed.rg.sorted.bam \
+            ${name}.vcfcheck.log \
+            ${name}.primersitereport.txt
         """
 }
 
@@ -126,6 +134,8 @@ process artic_nanopolish {
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}_mapped_*.primertrimmed.sorted.bam*"
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.trimmed.rg.sorted.bam"        
         publishDir "${params.output}/${params.genomedir}/all_consensus_sequences/", mode: 'copy', pattern: "*.consensus.fasta"
+        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.vcfcheck.log"
+        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.primersitereport.txt"
         publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "SNP_${name}.pass.vcf"
 
     input:
@@ -170,7 +180,9 @@ process artic_nanopolish {
             ${name}.pass.vcf.gz \
             ${name}.coverage_mask.txt.nCoV-2019_1.depths \
             ${name}.coverage_mask.txt.nCoV-2019_2.depths \
-            ${name}.trimmed.rg.sorted.bam
+            ${name}.trimmed.rg.sorted.bam \
+            ${name}.vcfcheck.log \
+            ${name}.primersitereport.txt
         """
 }
 
@@ -181,6 +193,8 @@ process artic_nanopolish_custom_bed {
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}_mapped_*.primertrimmed.sorted.bam*"
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.trimmed.rg.sorted.bam"        
         publishDir "${params.output}/${params.genomedir}/all_consensus_sequences/", mode: 'copy', pattern: "*.consensus.fasta"
+        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.vcfcheck.log"
+        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.primersitereport.txt"
         publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "SNP_${name}.pass.vcf"
 
     input:
@@ -236,7 +250,9 @@ process artic_nanopolish_custom_bed {
             ${name}.pass.vcf.gz \
             ${name}.coverage_mask.txt.nCoV-2019_1.depths \
             ${name}.coverage_mask.txt.nCoV-2019_2.depths \
-            ${name}.trimmed.rg.sorted.bam
+            ${name}.trimmed.rg.sorted.bam \
+            ${name}.vcfcheck.log \
+            ${name}.primersitereport.txt
         """
 }
 

--- a/workflows/process/artic.nf
+++ b/workflows/process/artic.nf
@@ -4,9 +4,10 @@ process artic_medaka {
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}_mapped_*.primertrimmed.sorted.bam*"
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.trimmed.rg.sorted.bam"
         publishDir "${params.output}/${params.genomedir}/all_consensus_sequences/", mode: 'copy', pattern: "*.consensus.fasta"
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.vcfcheck.log"
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.primersitereport.txt"
         publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "SNP_${name}.pass.vcf"
+        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "${name}.coverage_mask.txt"
+        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "${name}.fail.vcf"
 
     input:
         tuple val(name), path(reads), path(external_scheme)
@@ -16,6 +17,10 @@ process artic_medaka {
         tuple val(name), path("SNP_${name}.pass.vcf"), emit: vcf
         tuple val(name), path("${name}.pass.vcf.gz"), path("${name}.coverage_mask.txt.*1.depths"), path("${name}.coverage_mask.txt.*2.depths"), emit: covarplot
         tuple val(name), path("${name}.trimmed.rg.sorted.bam"), emit: fullbam
+        tuple val(name), path("${name}.primersitereport.txt"), emit: primersitereport
+        tuple val(name), path("${name}.coverage_mask.txt"), emit: coverage_mask
+        tuple val(name), path("${name}.fail.vcf"), emit: vcf_fail
+
     script:   
         """
         artic minion    --medaka \
@@ -52,8 +57,9 @@ process artic_medaka {
             ${name}.coverage_mask.txt.nCoV-2019_1.depths \
             ${name}.coverage_mask.txt.nCoV-2019_2.depths \
             ${name}.trimmed.rg.sorted.bam \
-            ${name}.vcfcheck.log \
-            ${name}.primersitereport.txt
+            ${name}.primersitereport.txt \
+            ${name}.coverage_mask.txt \
+            ${name}.fail.vcf
         """
 }
 
@@ -63,9 +69,10 @@ process artic_medaka_custom_bed {
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}_mapped_*.primertrimmed.sorted.bam*"
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.trimmed.rg.sorted.bam"
         publishDir "${params.output}/${params.genomedir}/all_consensus_sequences/", mode: 'copy', pattern: "*.consensus.fasta"
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.vcfcheck.log"
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.primersitereport.txt"
         publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "SNP_${name}.pass.vcf"
+        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "${name}.coverage_mask.txt"
+        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "${name}.fail.vcf"
 
     input:
         tuple val(name), path(reads), path(external_scheme), path(primerBed)
@@ -75,6 +82,9 @@ process artic_medaka_custom_bed {
         tuple val(name), path("SNP_${name}.pass.vcf"), emit: vcf
         tuple val(name), path("${name}.pass.vcf.gz"), path("${name}.coverage_mask.txt.*1.depths"), path("${name}.coverage_mask.txt.*2.depths"), emit: covarplot
         tuple val(name), path("${name}.trimmed.rg.sorted.bam"), emit: fullbam
+        tuple val(name), path("${name}.primersitereport.txt"), emit: primersitereport
+        tuple val(name), path("${name}.coverage_mask.txt"), emit: coverage_mask
+        tuple val(name), path("${name}.fail.vcf"), emit: vcf_fail
     script:   
         """
         # create a new primer dir as input for artic
@@ -122,8 +132,9 @@ process artic_medaka_custom_bed {
             ${name}.coverage_mask.txt.nCoV-2019_1.depths \
             ${name}.coverage_mask.txt.nCoV-2019_2.depths \
             ${name}.trimmed.rg.sorted.bam \
-            ${name}.vcfcheck.log \
-            ${name}.primersitereport.txt
+            ${name}.primersitereport.txt \
+            ${name}.coverage_mask.txt \
+            ${name}.fail.vcf
         """
 }
 
@@ -134,9 +145,10 @@ process artic_nanopolish {
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}_mapped_*.primertrimmed.sorted.bam*"
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.trimmed.rg.sorted.bam"        
         publishDir "${params.output}/${params.genomedir}/all_consensus_sequences/", mode: 'copy', pattern: "*.consensus.fasta"
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.vcfcheck.log"
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.primersitereport.txt"
         publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "SNP_${name}.pass.vcf"
+        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "${name}.coverage_mask.txt"
+        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "${name}.fail.vcf"
 
     input:
         tuple val(name), path(reads), path(external_scheme), path(fast5_dir), path(txt_files)
@@ -146,6 +158,9 @@ process artic_nanopolish {
         tuple val(name), path("SNP_${name}.pass.vcf"), emit: vcf
         tuple val(name), path("${name}.pass.vcf.gz"), path("${name}.coverage_mask.txt.*1.depths"), path("${name}.coverage_mask.txt.*2.depths"), emit: covarplot
         tuple val(name), path("${name}.trimmed.rg.sorted.bam"), emit: fullbam
+        tuple val(name), path("${name}.primersitereport.txt"), emit: primersitereport
+        tuple val(name), path("${name}.coverage_mask.txt"), emit: coverage_mask
+        tuple val(name), path("${name}.fail.vcf"), emit: vcf_fail
     script:   
         """
         artic minion --minimap2 --normalise 500 \
@@ -181,8 +196,9 @@ process artic_nanopolish {
             ${name}.coverage_mask.txt.nCoV-2019_1.depths \
             ${name}.coverage_mask.txt.nCoV-2019_2.depths \
             ${name}.trimmed.rg.sorted.bam \
-            ${name}.vcfcheck.log \
-            ${name}.primersitereport.txt
+            ${name}.primersitereport.txt \
+            ${name}.coverage_mask.txt \
+            ${name}.fail.vcf
         """
 }
 
@@ -193,9 +209,10 @@ process artic_nanopolish_custom_bed {
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}_mapped_*.primertrimmed.sorted.bam*"
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.trimmed.rg.sorted.bam"        
         publishDir "${params.output}/${params.genomedir}/all_consensus_sequences/", mode: 'copy', pattern: "*.consensus.fasta"
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.vcfcheck.log"
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.primersitereport.txt"
         publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "SNP_${name}.pass.vcf"
+        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "${name}.coverage_mask.txt"
+        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "${name}.fail.vcf"
 
     input:
         tuple val(name), path(reads), path(external_scheme), path(fast5_dir), path(txt_files), path(primerBed)
@@ -205,6 +222,9 @@ process artic_nanopolish_custom_bed {
         tuple val(name), path("SNP_${name}.pass.vcf"), emit: vcf
         tuple val(name), path("${name}.pass.vcf.gz"), path("${name}.coverage_mask.txt.*1.depths"), path("${name}.coverage_mask.txt.*2.depths"), emit: covarplot
         tuple val(name), path("${name}.trimmed.rg.sorted.bam"), emit: fullbam
+        tuple val(name), path("${name}.primersitereport.txt"), emit: primersitereport
+        tuple val(name), path("${name}.coverage_mask.txt"), emit: coverage_mask
+        tuple val(name), path("${name}.fail.vcf"), emit: vcf_fail
     script:   
         """
         # create a new primer dir as input for artic
@@ -251,8 +271,9 @@ process artic_nanopolish_custom_bed {
             ${name}.coverage_mask.txt.nCoV-2019_1.depths \
             ${name}.coverage_mask.txt.nCoV-2019_2.depths \
             ${name}.trimmed.rg.sorted.bam \
-            ${name}.vcfcheck.log \
-            ${name}.primersitereport.txt
+            ${name}.primersitereport.txt \
+            ${name}.coverage_mask.txt \
+            ${name}.fail.vcf
         """
 }
 


### PR DESCRIPTION
- publishes the following documents for each sample
  - `primersitereport.txt` -> variants in primer binding sites
  - `coverage_mask.txt` -> low coverage regions
  - `fail.vcf` -> filtered and failed variants that get masked with Ns
- solves #245 