### PR TITLE
Update medaka

### DIFF
--- a/configs/container.config
+++ b/configs/container.config
@@ -2,7 +2,7 @@ process {
     // DONT add GUPPY containers here !!! they are maintained via process
     // pangolin container is maintained via params.defaultpangolin in nextflow.config
     // nextclade container is maintained via params.defaultpangolin in nextflow.config
-    withLabel:  artic       { container = 'nanozoo/artic:1.3.0-dev--e22cdbc' }
+    withLabel:  artic       { container = 'nanozoo/artic:1.3.0-dev--784493e' }
     withLabel:  bwa         { container = 'nanozoo/bwa:0.7.17--d11c0a4' }
     withLabel:  covarplot   { container = 'nanozoo/covarplot:0.0.2--2c6e300' }
     withLabel:  demultiplex { container = 'nanozoo/guppy_cpu:5.0.7-1--47b84be' }

--- a/configs/container.config
+++ b/configs/container.config
@@ -2,7 +2,7 @@ process {
     // DONT add GUPPY containers here !!! they are maintained via process
     // pangolin container is maintained via params.defaultpangolin in nextflow.config
     // nextclade container is maintained via params.defaultpangolin in nextflow.config
-    withLabel:  artic       { container = 'nanozoo/artic:1.3.0-dev--a15e2ee' }
+    withLabel:  artic       { container = 'nanozoo/artic:1.3.0-dev--e22cdbc' }
     withLabel:  bwa         { container = 'nanozoo/bwa:0.7.17--d11c0a4' }
     withLabel:  covarplot   { container = 'nanozoo/covarplot:0.0.2--2c6e300' }
     withLabel:  demultiplex { container = 'nanozoo/guppy_cpu:5.0.7-1--47b84be' }


### PR DESCRIPTION
The updated container includes the medaka v1.8.0 model for 5 kHz data (r1041_e82_400bps_sup_v4.2.0)

Fixes #254 