### PR TITLE
bump default container version for pangolin and nextclade

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -48,8 +48,8 @@ params {
     lcs_ucsc_downsampling = 10000 // 'None' to turn off
     lcs_variant_groups = 'default' // 'default' to use file from repo; custom variant groups table for marker-table update
     lcs_cutoff = 0.03
-    defaultpangolin = 'nanozoo/pangolin-v4:4.1.1--1.11'
-    defaultnextclade = 'nanozoo/nextclade2:2.2.0--2022-06-14'
+    defaultpangolin = 'nanozoo/pangolin-v4:4.3--1.25.1'
+    defaultnextclade = 'nanozoo/nextclade3:3.2.1--2024-02-16'
     scorpio = false
 
     // parameters

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -256,15 +256,15 @@ println "\033[0;33mWarning: Running --update might not be poreCov compatible!\03
         params.pangolindocker = "nanozoo/pangolin-v4:" + tagname
         println "\033[0;32mFound latest pangolin container, using: " + params.pangolindocker + " \033[0m" 
 
-        tagname = 'https://registry.hub.docker.com/v2/repositories/nanozoo/nextclade2/tags/'.toURL().text.split(',"name":"')[1].split('","')[0]
-        params.nextcladedocker = "nanozoo/nextclade2:" + tagname 
-        println "\033[0;32mFound latest nextclade2 container, using: " + params.nextcladedocker + " \033[0m"
+        tagname = 'https://registry.hub.docker.com/v2/repositories/nanozoo/nextclade3/tags/'.toURL().text.split(',"name":"')[1].split('","')[0]
+        params.nextcladedocker = "nanozoo/nextclade3:" + tagname 
+        println "\033[0;32mFound latest nextclade3 container, using: " + params.nextcladedocker + " \033[0m"
     } 
     if ( internetcheck.toString() == "false" ) { 
         println "\033[0;33mCould not find the latest pangolin container, trying: " + params.defaultpangolin + "\033[0m"
         params.pangolindocker = params.defaultpangolin 
 
-        println "\033[0;33mCould not find the latest nextclade2 container, trying: " + params.defaultnextclade + "\033[0m"
+        println "\033[0;33mCould not find the latest nextclade3 container, trying: " + params.defaultnextclade + "\033[0m"
         params.nextcladedocker = params.defaultnextclade 
     } 
 }


### PR DESCRIPTION
bump to latest containers:
- nanozoo/pangolin-v4:4.3--1.25.1
- nanozoo/nextclade3:3.2.1--2024-02-16