### PR TITLE
skip removing small fastq.gz files after the length filter with --list or --sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Table of Contents
     - [Custom primer bed files](#custom-primer-bed-files)
     - [Sample input](#sample-input)
       - [Sample sheet](#sample-sheet)
-      - [--list](#--list)
+      - [List input](#list-input)
     - [Pangolin Lineage definitions](#pangolin-lineage-definitions)
 - [3. Quality Metrics (default)](#3-quality-metrics-default)
 - [4. Workflow](#4-workflow)
@@ -172,7 +172,7 @@ MN908947.3	4240	4262	nCoV-2019_4_RIGHT	nCoV-2019_2	-
 ### Sample input
 
 > [!NOTE]  
-> For fastq input without `--sample` and `--list`, samples with less than 1500 kB fastq file size after concatenation and size selection, are removed.
+> If using --fastq without either --sample or --list, samples whose concatenated and size-selected FastQ files are smaller than 1500 kB will be excluded from further analysis.
 
 #### Sample sheet
 * barcodes can be automatically renamed via `--samples sample_names.csv`
@@ -189,14 +189,19 @@ Sample_2021,barcode01,good
 2ndSample,BC02,bad
 ```
 
-#### --list
+#### List input
+* Using `--list` You can provide a csv as input to `--fastq` to select for specific fastq-files
+  * e.g.: `--fastq input.csv --list`
+  * the csv needs to contain two columns:
+    * column 1 = sample name
+    * column 2 = path to fastq-location
+  * no header should be used
+* files get automatically renamed to the sample names provided in column 1
 
-* alternatively fastq files can automatically renamed via `--fastq list.csv --list`
-* no header required, example:
-
+ Example:
 ```csv
-sample1,path_to_first_sample.fastq.gz
-sample2,path_to_second_sample.fastq.gz
+sample1,path/to/first/sample.fastq.gz
+2ndSample,path/to/second/sample.fastq.gz
 ```
  
 ### Pangolin Lineage definitions

--- a/README.md
+++ b/README.md
@@ -167,7 +167,12 @@ MN908947.3	3144	3166	nCoV-2019_4_LEFT	nCoV-2019_2	+
 MN908947.3	4240	4262	nCoV-2019_4_RIGHT	nCoV-2019_2	-
 ```
 
-### Sample sheet
+### Sample input
+
+> [!NOTE]  
+> For fastq input without `--sample` and `--list`, samples with less then 1500 kB file size after fastq concatenation and size selection, are removed.
+
+#### Sample sheet
 * barcodes can be automatically renamed via `--samples sample_names.csv`
 * required columns:
   * `_id` = sample name
@@ -181,7 +186,17 @@ _id,Status,Description
 Sample_2021,barcode01,good
 2ndSample,BC02,bad
 ```
-  
+
+#### --list
+
+* alternatively, fasta and fastq files can automatically renamed via `--fast[a|q] list.csv --list`
+* no header required, example:
+
+```csv
+sample1,path_to_first_sample.fastq.gz
+sample2,path_to_second_sample.fastq.gz
+```
+ 
 ### Pangolin Lineage definitions
   * lineage determinations are quickly changing in response to the pandemic
   * to avoid using out of date lineage schemes, a `--update` flag can be added to each poreCov run to get the most recent version-controlled pangolin container

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Table of Contents
     - [Version control](#version-control)
     - [Important input flags (choose one)](#important-input-flags-choose-one)
     - [Custom primer bed files](#custom-primer-bed-files)
-    - [Sample sheet](#sample-sheet)
+    - [Sample input](#sample-input)
+      - [Sample sheet](#sample-sheet)
+      - [--list](#--list)
     - [Pangolin Lineage definitions](#pangolin-lineage-definitions)
 - [3. Quality Metrics (default)](#3-quality-metrics-default)
 - [4. Workflow](#4-workflow)
@@ -170,7 +172,7 @@ MN908947.3	4240	4262	nCoV-2019_4_RIGHT	nCoV-2019_2	-
 ### Sample input
 
 > [!NOTE]  
-> For fastq input without `--sample` and `--list`, samples with less then 1500 kB file size after fastq concatenation and size selection, are removed.
+> For fastq input without `--sample` and `--list`, samples with less than 1500 kB fastq file size after concatenation and size selection, are removed.
 
 #### Sample sheet
 * barcodes can be automatically renamed via `--samples sample_names.csv`
@@ -189,7 +191,7 @@ Sample_2021,barcode01,good
 
 #### --list
 
-* alternatively, fasta and fastq files can automatically renamed via `--fast[a|q] list.csv --list`
+* alternatively fastq files can automatically renamed via `--fastq list.csv --list`
 * no header required, example:
 
 ```csv

--- a/modules/filter_fastq_by_length.nf
+++ b/modules/filter_fastq_by_length.nf
@@ -31,7 +31,7 @@ process filter_fastq_by_length {
             ;;
         esac
         
-        if [ ${params.samples} == false ]; then
+        if [ ${params.samples} == false ] && [ ${params.list} == false ]; then
             find . -name "${name}_filtered.fastq.gz" -type 'f' -size -1500k -delete
         fi
         """

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -164,7 +164,7 @@ if (params.samples) {
         fasta_input_raw_ch = Channel
         .fromPath( params.fasta, checkIfExists: true )
         .splitCsv()
-        .map { row -> file("${row[1]}", checkIfExists: true) }
+        .map { row -> ["${row[0]}", file("${row[1]}", checkIfExists: true)] }
     }
 
 // consensus qc reference input - auto using git default if not specified
@@ -417,7 +417,11 @@ workflow {
     // 2. Genome quality, lineages, clades and mutations
         // fasta input
         if ( params.fasta || workflow.profile.contains('test_fasta' ) ) {
-            fasta_input_ch = split_fasta(fasta_input_raw_ch).flatten().map { it -> tuple(it.simpleName, it) }
+            if (parmas.list) {
+                fasta_input_ch = fasta_input_raw_ch
+            } else {
+                fasta_input_ch = split_fasta(fasta_input_raw_ch).flatten().map { it -> tuple(it.simpleName, it) }
+            }
         }
 
         determine_lineage_wf(fasta_input_ch)

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -103,6 +103,7 @@ if (!workflow.profile.contains('test_fastq') && !workflow.profile.contains('test
     if ( params.fasta && ( params.fastq || params.fast5 || params.fastq_pass)) { exit 1, "Please use [--fasta] without inputs like: [--fastq], [--fastq_pass], [--fast5]" }
     if (( params.fastq || params.fastq_pass ) && params.fast5 && !params.nanopolish ) { 
         exit 1, "Simultaneous fastq and fast5 input is only supported with [--nanopolish]"}
+    if (params.list && params.fasta) { exit 1, "[--fasta] and [--list] is not supported" }
 
 }
 if ( (params.cores.toInteger() > params.max_cores.toInteger()) && workflow.profile.contains('local')) {
@@ -156,15 +157,9 @@ if (params.samples) {
 **************************/
 
 // fasta input 
-    if (!params.list && params.fasta && !workflow.profile.contains('test_fasta')) { 
+    if (params.fasta && !workflow.profile.contains('test_fasta')) { 
         fasta_input_raw_ch = Channel
         .fromPath( params.fasta, checkIfExists: true)
-    }
-    else if (params.list && params.fasta && !workflow.profile.contains('test_fasta')) { 
-        fasta_input_raw_ch = Channel
-        .fromPath( params.fasta, checkIfExists: true )
-        .splitCsv()
-        .map { row -> file("${row[1]}", checkIfExists: true) }
     }
 
 // consensus qc reference input - auto using git default if not specified
@@ -508,7 +503,7 @@ ${c_yellow}Workflow control (optional)${c_reset}
                              Status,_id
                              barcode01,sample2011XY
                              BC02,thirdsample_run
-    --list                   --fast[a|q] is a csv file containing a new sample name and the path (no header), e.g.:
+    --list                   --fastq is a csv file containing a new sample name and the path (no header), e.g.:
                              sample1,path_to_first_sample.fastq.gz
                              sample2,path_to_second_sample.fastq.gz
     --extended               poreCov utilizes from --samples these additional headers:

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -417,7 +417,7 @@ workflow {
     // 2. Genome quality, lineages, clades and mutations
         // fasta input
         if ( params.fasta || workflow.profile.contains('test_fasta' ) ) {
-            if (parmas.list) {
+            if (params.list) {
                 fasta_input_ch = fasta_input_raw_ch
             } else {
                 fasta_input_ch = split_fasta(fasta_input_raw_ch).flatten().map { it -> tuple(it.simpleName, it) }

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -508,6 +508,9 @@ ${c_yellow}Workflow control (optional)${c_reset}
                              Status,_id
                              barcode01,sample2011XY
                              BC02,thirdsample_run
+    --list                   --fast[a|q] is a csv file containing a new sample name and the path (no header), e.g.:
+                             sample1,path_to_first_sample.fastq.gz
+                             sample2,path_to_second_sample.fastq.gz
     --extended               poreCov utilizes from --samples these additional headers:
                              Submitting_Lab,Isolation_Date,Seq_Reason,Sample_Type
     --nanopolish             use nanopolish instead of medaka for ARTIC (needs --fast5)

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -164,7 +164,7 @@ if (params.samples) {
         fasta_input_raw_ch = Channel
         .fromPath( params.fasta, checkIfExists: true )
         .splitCsv()
-        .map { row -> ["${row[0]}", file("${row[1]}", checkIfExists: true)] }
+        .map { row -> file("${row[1]}", checkIfExists: true) }
     }
 
 // consensus qc reference input - auto using git default if not specified
@@ -417,11 +417,7 @@ workflow {
     // 2. Genome quality, lineages, clades and mutations
         // fasta input
         if ( params.fasta || workflow.profile.contains('test_fasta' ) ) {
-            if (params.list) {
-                fasta_input_ch = fasta_input_raw_ch
-            } else {
-                fasta_input_ch = split_fasta(fasta_input_raw_ch).flatten().map { it -> tuple(it.simpleName, it) }
-            }
+            fasta_input_ch = split_fasta(fasta_input_raw_ch).flatten().map { it -> tuple(it.simpleName, it) }
         }
 
         determine_lineage_wf(fasta_input_ch)

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -503,9 +503,10 @@ ${c_yellow}Workflow control (optional)${c_reset}
                              Status,_id
                              barcode01,sample2011XY
                              BC02,thirdsample_run
-    --list                   --fastq is a csv file containing a new sample name and the path (no header), e.g.:
-                             sample1,path_to_first_sample.fastq.gz
-                             sample2,path_to_second_sample.fastq.gz
+    --list                   --fastq takes a csv file containing (new) sample names and paths to the fastq-files (no header).
+                             Paths need to start with '/' or poreCov searches the files in the current working dir, e.g.:
+                             sample1,/path_to_first_sample.fastq.gz
+                             sample2,/path_to_second_sample.fastq.gz
     --extended               poreCov utilizes from --samples these additional headers:
                              Submitting_Lab,Isolation_Date,Seq_Reason,Sample_Type
     --nanopolish             use nanopolish instead of medaka for ARTIC (needs --fast5)


### PR DESCRIPTION
Hi folks,

We have been using `--fastq_pass --samples` as input configuration, but we will switch to `--fastq --list` at some point. While testing, I noticed that the negative control didn't appear in the reports.

Now, I'm not sure if I understand the reasoning behind these lines completely: https://github.com/replikation/poreCov/blob/master/modules/filter_fastq_by_length.nf#L34-L36

However, we'd still like to have the negative control in the report, so with this PR, the removal of small fastq.gz files after the length filter is skipped with `--list` or `--sample`.