### PR TITLE
Change get porcov version

### DIFF
--- a/lib/Git_PoreCov.groovy
+++ b/lib/Git_PoreCov.groovy
@@ -1,19 +1,22 @@
 import java.net.URL
 import java.net.URLConnection
+import groovy.json.JsonSlurper
 
-class Git_PoreCov {
-    
-    static boolean IsGitAvailable() {
+    /**
+     * Gets the latest version of a GitHub repository
+     * @return Latest version string
+     */
+    static String getLatestVersion() {
         try {
-            final URL url = new URL("https://api.github.com/repos/replikation/poreCov/releases/latest");
-            final URLConnection conn = url.openConnection();
-            conn.connect();
-            conn.getInputStream().close();
-            return true;
-        } catch (MalformedURLException e) {
-            return false;
-        } catch (IOException e) {
-            return false;
+            final URL url = new URL("https://api.github.com/repos/replikation/poreCov/releases/latest")
+            def response = url.getText(requestProperties: [
+                Accept: 'application/json'
+            ]);
+            
+            def json = new JsonSlurper().parseText(response);
+            return json.tag_name ?: json.name;
+        } catch (Exception e) {
+            println "Error fetching version: ${e.message}";
+            return 'Could not get version info';
         }
     }
-}

--- a/lib/Git_PoreCov.groovy
+++ b/lib/Git_PoreCov.groovy
@@ -1,7 +1,7 @@
 import java.net.URL
-import java.net.URLConnection
 import groovy.json.JsonSlurper
 
+class Git_PoreCov {
     /**
      * Gets the latest version of a GitHub repository
      * @return Latest version string
@@ -20,3 +20,4 @@ import groovy.json.JsonSlurper
             return 'Could not get version info';
         }
     }
+}

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -47,12 +47,12 @@ workflow {
 
 // try to check for poreCov releases
 
-    if ( Git_PoreCov.IsGitAvailable().toString() == "true" ) { porecovrelease = 'https://api.github.com/repos/replikation/poreCov/releases/latest'.toURL().text.split('"tag_name":"')[1].split('","')[0] } 
-    else { porecovrelease = 'Could not get version info' } 
+    // if ( Git_PoreCov.IsGitAvailable().toString() == "true" ) { porecovrelease = 'https://api.github.com/repos/replikation/poreCov/releases/latest'.toURL().text.split('"tag_name":"')[1].split('","')[0] } 
+    // else { porecovrelease = 'Could not get version info' } 
 
 
     println " "
-    println "  Latest available poreCov release: " + porecovrelease
+    println "  Latest available poreCov release: " + Git_PoreCov.getLatestVersion()
     println "  If neccessary update via: nextflow pull replikation/poreCov"
     println "________________________________________________________________________________"
 

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -47,10 +47,6 @@ workflow {
 
 // try to check for poreCov releases
 
-    // if ( Git_PoreCov.IsGitAvailable().toString() == "true" ) { porecovrelease = 'https://api.github.com/repos/replikation/poreCov/releases/latest'.toURL().text.split('"tag_name":"')[1].split('","')[0] } 
-    // else { porecovrelease = 'Could not get version info' } 
-
-
     println " "
     println "  Latest available poreCov release: " + Git_PoreCov.getLatestVersion()
     println "  If neccessary update via: nextflow pull replikation/poreCov"


### PR DESCRIPTION
Hi there, 
it's me again, again with the [same line](https://github.com/replikation/poreCov/blob/master/poreCov.nf#L50) and I can't explain why and how.

With Nextflow `24.10.4`, I get, sometimes, not always, a json/text returned that has spaces between the key-value pairs. This leads to an index out of bounds error, because the splitting does not work as expected.

```
Pulling replikation/poreCov ...
Launching `https://github.com/replikation/poreCov` [sleepy_fourier] DSL2 - revision: aa377dc669 [1.12.2]

________________________________________________________________________________
    
poreCov | A Nextflow SARS-CoV-2 workflow for nanopore data
    
ERROR ~ Index 1 out of bounds for length 1
 -- Check script '<myhome>/replikation/poreCov/poreCov.nf' at line: 50 or see '<foo>/poreCov.nextflow.log' file for more details
```
Excerpt from `'https://api.github.com/repos/replikation/poreCov/releases/latest'.toURL().text`:
```
<...>
  "tag_name": "1.12.2", <--- ":<space>"
  "target_commitish": "master",
<...>
```

Anyhow, I changed the Groovy function to get the latest release.

I hope this solves the issue on my side, and works for anyone else, too.