### PR TITLE
added `--min_qual` parameter

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -28,6 +28,7 @@ params {
     seq_threshold = '0.90'
     n_threshold = '0.05'
     min_depth = '20'
+    min_qual = '20'
 
     // settings
     buildDB = false

--- a/poreCov.nf
+++ b/poreCov.nf
@@ -489,6 +489,7 @@ ${c_yellow}Parameters - SARS-CoV-2 genome reconstruction (optional)${c_reset}
   --maxLength     Max length filter raw reads 
                   [default: 700 (primer-scheme: V1-4, rapid); 1500 (primer-scheme: V1200, V5.2.0_1200)]
   --min_depth     Nucleotides below min depth will be masked to "N" [default ${params.min_depth}]
+  --min_qual      Minimum variant quality for consensus masking [default ${params.min_qual}]
   --medaka_model  Medaka model for the artic workflow [default: ${params.medaka_model}]
                   ${c_dim}e.g. "r941_min_hac_g507" or "r941_min_sup_g507"${c_reset}
 

--- a/workflows/process/artic.nf
+++ b/workflows/process/artic.nf
@@ -107,6 +107,7 @@ process artic_medaka_custom_bed {
         artic minion    --medaka \
                         --medaka-model ${params.medaka_model} \
                         --min-depth ${params.min_depth} \
+                        --min-qual ${params.min_qual} \
                         ${normalise_arg} \
                         --threads ${task.cpus} \
                         --scheme-directory primer_scheme \

--- a/workflows/process/artic.nf
+++ b/workflows/process/artic.nf
@@ -28,6 +28,7 @@ process artic_medaka {
         artic minion    --medaka \
                         --medaka-model ${params.medaka_model} \
                         --min-depth ${params.min_depth} \
+                        --min-qual ${params.min_qual} \
                         ${normalise_arg} \
                         --threads ${task.cpus} \
                         --scheme-directory ${external_scheme} \


### PR DESCRIPTION
- sets the minimum variant quality for consensus masking in the ARTIC workflow
- (ARTIC) default is `20`

I run the pipeline locally without errors and expected outcome changes.