### PR TITLE
ignore artic-medaka fails with exit status 20

### DIFF
--- a/poreCov.nf
+++ b/poreCov.nf
@@ -313,7 +313,7 @@ workflow {
 
             // rename barcodes based on --samples input.csv
                 if (params.samples) { fastq_input_ch = fastq_input_raw_ch.join(samples_input_ch).map { it -> tuple(it[2],it[1])} 
-                   fastq_input_raw_ch.join(samples_input_ch).ifEmpty{ exit 2, "Could not match barcode numbers from $params.samples to the read files, some typo?"} 
+                    fastq_input_raw_ch.join(samples_input_ch).ifEmpty{ exit 2, "Could not match barcode numbers from $params.samples to the read files, some typo?"} 
                 }
                 else if (!params.samples) { fastq_input_ch = fastq_input_raw_ch }
 

--- a/workflows/process/artic.nf
+++ b/workflows/process/artic.nf
@@ -1,5 +1,6 @@
 process artic_medaka {
         label 'artic'
+        errorStrategy {task.exitStatus == 20 ? 'ignore' : 'retry'}
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "*.consensus.fasta"
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}_mapped_*.primertrimmed.sorted.bam*"
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.trimmed.rg.sorted.bam"
@@ -68,6 +69,7 @@ process artic_medaka {
 
 process artic_medaka_custom_bed {
         label 'artic'
+        errorStrategy {task.exitStatus == 20 ? 'ignore' : 'retry'}
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "*.consensus.fasta"
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}_mapped_*.primertrimmed.sorted.bam*"
         publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.trimmed.rg.sorted.bam"


### PR DESCRIPTION
- when no reads map to the reference, ARTIC medaka fails with a segfault while reading an empty VCF file (see vcfcheck.log in workdir)
<img width="664" height="122" alt="grafik" src="https://github.com/user-attachments/assets/0340f111-5ede-47c6-bafc-89e3d19aba75" />


I would have liked to catch such samples before the ARTIC step, however Kraken2 classifies some reads as SC2, which do not map in the end

Let me know it it makes sense or you have a good idea for a solution!