### PR TITLE
Adjusted to new strict syntax of nextflow version 26.04

### DIFF
--- a/modules/add_alt_allele_ratio_vcf.nf
+++ b/modules/add_alt_allele_ratio_vcf.nf
@@ -1,6 +1,6 @@
 process add_alt_allele_ratio_vcf {
     label 'artic'
-    publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy'
+    publishDir { "${params.output}/${params.lineagedir}/${name}/" }, mode: 'copy'
     input:
         tuple val(name), path(bam), path(bai), path(vcf), path(failed_vcf)
         path(external_scheme) // primer scheme dir as input

--- a/modules/filter_fastq_by_length.nf
+++ b/modules/filter_fastq_by_length.nf
@@ -1,6 +1,6 @@
 process filter_fastq_by_length {
         label 'ubuntu'
-        publishDir "${params.output}/${params.readsdir}/filtered_reads/", mode: 'copy', pattern: "${name}_filtered.fastq.gz"
+        publishDir "${params.output}/${params.readsdir}/filtered_reads/", mode: 'copy', pattern: { "${name}_filtered.fastq.gz" }
     input:
         tuple val(name), path(reads) 
     output:

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,6 +12,7 @@ params {
     help = false
     profile = false
     trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
+    user = System.getenv('USER')
 
     // inputs
     fast5 = ''
@@ -116,7 +117,7 @@ profiles {
 
 
     local {
-        workDir = "work/nextflow-poreCov-$USER"
+        workDir = "work/nextflow-poreCov-${params.user}"
         includeConfig 'configs/local.config'
         executor {
             name = "local"

--- a/workflows/process/artic.nf
+++ b/workflows/process/artic.nf
@@ -1,13 +1,13 @@
 process artic_medaka {
         label 'artic'
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "*.consensus.fasta"
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}_mapped_*.primertrimmed.sorted.bam*"
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.trimmed.rg.sorted.bam"
-        publishDir "${params.output}/${params.genomedir}/all_consensus_sequences/", mode: 'copy', pattern: "*.consensus.fasta"
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.primersitereport.txt"
-        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "SNP_${name}.pass.vcf"
-        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "${name}.coverage_mask.txt"
-        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "${name}.fail.vcf"
+        publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy', pattern: "*.consensus.fasta"
+        publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy', pattern: { "${name}_mapped_*.primertrimmed.sorted.bam*" }
+        publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy', pattern: { "${name}.trimmed.rg.sorted.bam" }
+        publishDir { "${params.output}/${params.genomedir}/all_consensus_sequences/" }, mode: 'copy', pattern: "*.consensus.fasta"
+        publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy', pattern: { "${name}.primersitereport.txt" }
+        publishDir { "${params.output}/${params.lineagedir}/${name}/" }, mode: 'copy', pattern: { "SNP_${name}.pass.vcf" }
+        publishDir { "${params.output}/${params.lineagedir}/${name}/" }, mode: 'copy', pattern: { "${name}.coverage_mask.txt" }
+        publishDir { "${params.output}/${params.lineagedir}/${name}/" }, mode: 'copy', pattern: { "${name}.fail.vcf" }
 
     input:
         tuple val(name), path(reads), path(external_scheme)
@@ -68,14 +68,14 @@ process artic_medaka {
 
 process artic_medaka_custom_bed {
         label 'artic'
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "*.consensus.fasta"
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}_mapped_*.primertrimmed.sorted.bam*"
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.trimmed.rg.sorted.bam"
-        publishDir "${params.output}/${params.genomedir}/all_consensus_sequences/", mode: 'copy', pattern: "*.consensus.fasta"
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.primersitereport.txt"
-        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "SNP_${name}.pass.vcf"
-        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "${name}.coverage_mask.txt"
-        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "${name}.fail.vcf"
+        publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy', pattern: "*.consensus.fasta"
+        publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy', pattern: { "${name}_mapped_*.primertrimmed.sorted.bam*" }
+        publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy', pattern: { "${name}.trimmed.rg.sorted.bam" }
+        publishDir { "${params.output}/${params.genomedir}/all_consensus_sequences/" }, mode: 'copy', pattern: "*.consensus.fasta"
+        publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy', pattern: { "${name}.primersitereport.txt" }
+        publishDir { "${params.output}/${params.lineagedir}/${name}/" }, mode: 'copy', pattern: { "SNP_${name}.pass.vcf" }
+        publishDir { "${params.output}/${params.lineagedir}/${name}/" }, mode: 'copy', pattern: { "${name}.coverage_mask.txt" }
+        publishDir { "${params.output}/${params.lineagedir}/${name}/" }, mode: 'copy', pattern: { "${name}.fail.vcf" }
 
     input:
         tuple val(name), path(reads), path(external_scheme), path(primerBed)
@@ -148,14 +148,14 @@ process artic_medaka_custom_bed {
 
 process artic_nanopolish {
         label 'artic'
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "*.consensus.fasta"
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}_mapped_*.primertrimmed.sorted.bam*"
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.trimmed.rg.sorted.bam"        
-        publishDir "${params.output}/${params.genomedir}/all_consensus_sequences/", mode: 'copy', pattern: "*.consensus.fasta"
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.primersitereport.txt"
-        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "SNP_${name}.pass.vcf"
-        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "${name}.coverage_mask.txt"
-        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "${name}.fail.vcf"
+        publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy', pattern: "*.consensus.fasta"
+        publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy', pattern: { "${name}_mapped_*.primertrimmed.sorted.bam*" }
+        publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy', pattern: { "${name}.trimmed.rg.sorted.bam" }
+        publishDir { "${params.output}/${params.genomedir}/all_consensus_sequences/" }, mode: 'copy', pattern: "*.consensus.fasta"
+        publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy', pattern: { "${name}.primersitereport.txt" }
+        publishDir { "${params.output}/${params.lineagedir}/${name}/" }, mode: 'copy', pattern: { "SNP_${name}.pass.vcf" }
+        publishDir { "${params.output}/${params.lineagedir}/${name}/" }, mode: 'copy', pattern: { "${name}.coverage_mask.txt" }
+        publishDir { "${params.output}/${params.lineagedir}/${name}/" }, mode: 'copy', pattern: { "${name}.fail.vcf" }
 
     input:
         tuple val(name), path(reads), path(external_scheme), path(fast5_dir), path(txt_files)
@@ -215,14 +215,14 @@ process artic_nanopolish {
 
 process artic_nanopolish_custom_bed {
         label 'artic'
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "*.consensus.fasta"
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}_mapped_*.primertrimmed.sorted.bam*"
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.trimmed.rg.sorted.bam"        
-        publishDir "${params.output}/${params.genomedir}/all_consensus_sequences/", mode: 'copy', pattern: "*.consensus.fasta"
-        publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "${name}.primersitereport.txt"
-        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "SNP_${name}.pass.vcf"
-        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "${name}.coverage_mask.txt"
-        publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "${name}.fail.vcf"
+        publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy', pattern: "*.consensus.fasta"
+        publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy', pattern: { "${name}_mapped_*.primertrimmed.sorted.bam*" }
+        publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy', pattern: { "${name}.trimmed.rg.sorted.bam" }
+        publishDir { "${params.output}/${params.genomedir}/all_consensus_sequences/" }, mode: 'copy', pattern: "*.consensus.fasta"
+        publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy', pattern: { "${name}.primersitereport.txt" }
+        publishDir { "${params.output}/${params.lineagedir}/${name}/" }, mode: 'copy', pattern: { "SNP_${name}.pass.vcf" }
+        publishDir { "${params.output}/${params.lineagedir}/${name}/" }, mode: 'copy', pattern: { "${name}.coverage_mask.txt" }
+        publishDir { "${params.output}/${params.lineagedir}/${name}/" }, mode: 'copy', pattern: { "${name}.fail.vcf" }
 
     input:
         tuple val(name), path(reads), path(external_scheme), path(fast5_dir), path(txt_files), path(primerBed)

--- a/workflows/process/covarplot.nf
+++ b/workflows/process/covarplot.nf
@@ -1,6 +1,6 @@
 process covarplot {
     label "covarplot"
-    publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy'
+    publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy'
     input:
         tuple val(name), path(vcf), path(depth1), path(depth2), path(primerbed)
     output:
@@ -20,7 +20,7 @@ process covarplot {
 
 process covarplot_custom_bed {
     label "covarplot"
-    publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy'
+    publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy'
     input:
         tuple val(name), path(vcf), path(depth1), path(depth2), path(primerbed)
     output:

--- a/workflows/process/freyja.nf
+++ b/workflows/process/freyja.nf
@@ -2,7 +2,7 @@ process freyja {
         label 'freyja'
         errorStrategy 'ignore'
         maxRetries 1
-        publishDir "${params.output}/${params.lineagedir}/${name}/lineage-proportion-by-reads", mode: 'copy', pattern: "*"
+        publishDir { "${params.output}/${params.lineagedir}/${name}/lineage-proportion-by-reads" }, mode: 'copy', pattern: "*"
 
     input:
         tuple val(name), path(bam_file), path(reference)
@@ -69,7 +69,7 @@ process freyja {
 
 process freyja_plot {
         label 'freyja'
-        publishDir "${params.output}/${params.lineagedir}/", mode: 'copy', pattern: "*"
+        publishDir { "${params.output}/${params.lineagedir}/" }, mode: 'copy', pattern: "*"
 
     input:
         path(aggregate_file)

--- a/workflows/process/kraken2.nf
+++ b/workflows/process/kraken2.nf
@@ -1,6 +1,6 @@
 process kraken2 {
         label 'kraken2'
-        publishDir "${params.output}/${params.readqcdir}/${name}/tax_read_classification", mode: 'copy'
+        publishDir { "${params.output}/${params.readqcdir}/${name}/tax_read_classification" }, mode: 'copy'
     input:
         tuple val(name), path(reads)
         path(database)

--- a/workflows/process/krona.nf
+++ b/workflows/process/krona.nf
@@ -1,6 +1,6 @@
 process krona {
         label 'krona'
-        publishDir "${params.output}/${params.readqcdir}/${name}/", mode: 'copy'
+        publishDir { "${params.output}/${params.readqcdir}/${name}/" }, mode: 'copy'
     input:
         tuple val(name), path(kraken2), path(kreport)
   	output:

--- a/workflows/process/lcs_sc2.nf
+++ b/workflows/process/lcs_sc2.nf
@@ -45,7 +45,7 @@ process lcs_ucsc_markers_table {
 
 process lcs_sc2 {
     label 'lcs_sc2'
-    publishDir "${params.output}/${params.lineagedir}/${name}/lineage-proportion-by-reads", mode: 'copy'
+    publishDir { "${params.output}/${params.lineagedir}/${name}/lineage-proportion-by-reads" }, mode: 'copy'
     input:
     tuple val(name), path(reads), path(ucsc_markers_table)
   	output:

--- a/workflows/process/nanoplot.nf
+++ b/workflows/process/nanoplot.nf
@@ -1,9 +1,9 @@
 process nanoplot {
     label 'nanoplot'
-    publishDir "${params.output}/${params.readqcdir}/${name}/", mode: 'copy', pattern: "${name}_read_quality_report.html"
-    publishDir "${params.output}/${params.readqcdir}/${name}/", mode: 'copy', pattern: "${name}_read_quality.txt"
-    publishDir "${params.output}/${params.readqcdir}/${name}/figures", mode: 'copy', pattern: "*.png"
-    publishDir "${params.output}/${params.readqcdir}/${name}/vector_figures", mode: 'copy', pattern: "*.pdf"
+    publishDir { "${params.output}/${params.readqcdir}/${name}/" }, mode: 'copy', pattern: { "${name}_read_quality_report.html" }
+    publishDir { "${params.output}/${params.readqcdir}/${name}/" }, mode: 'copy', pattern: { "${name}_read_quality.txt" }
+    publishDir { "${params.output}/${params.readqcdir}/${name}/figures" }, mode: 'copy', pattern: "*.png"
+    publishDir { "${params.output}/${params.readqcdir}/${name}/vector_figures" }, mode: 'copy', pattern: "*.pdf"
     input:
         tuple val(name), path(reads)
     output:

--- a/workflows/process/nextclade.nf
+++ b/workflows/process/nextclade.nf
@@ -1,7 +1,7 @@
 process nextclade {
     label 'nextclade'
     container { nextcladedocker }
-    publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "${name}_clade.tsv"
+    publishDir { "${params.output}/${params.lineagedir}/${name}/" }, mode: 'copy', pattern: { "${name}_clade.tsv" }
     input:
         tuple val(name), path(consensus)
         val(nextcladedocker)

--- a/workflows/process/pangolin.nf
+++ b/workflows/process/pangolin.nf
@@ -1,7 +1,7 @@
 process pangolin {
     label 'pangolin'
     container { pangolindocker }
-    publishDir "${params.output}/${params.lineagedir}/${name}/", mode: 'copy', pattern: "lineage_report_${name}.csv"
+    publishDir { "${params.output}/${params.lineagedir}/${name}/" }, mode: 'copy', pattern: { "lineage_report_${name}.csv" }
   input:
     tuple val(name), path(fasta)
     val(pangolindocker)

--- a/workflows/process/president.nf
+++ b/workflows/process/president.nf
@@ -1,6 +1,6 @@
 process president {
     label "president"
-    publishDir "${params.output}/${params.genomedir}/${name}", mode: 'copy',
+    publishDir { "${params.output}/${params.genomedir}/${name}" }, mode: 'copy',
         saveAs: { filename -> if (filename.endsWith("${name}_report.tsv")) "${name}_seq_ident_check.tsv" }
     input:
         tuple val(name), path(fasta), path(reference_fasta)

--- a/workflows/process/pycoqc.nf
+++ b/workflows/process/pycoqc.nf
@@ -1,6 +1,6 @@
 process pycoqc {
         label 'pycoqc'  
-        publishDir "${params.output}/${params.readqcdir}/", mode: 'copy', pattern: "${name}_sequencing_performance.html"
+        publishDir "${params.output}/${params.readqcdir}/", mode: 'copy', pattern: { "${name}_sequencing_performance.html" }
     input:
         tuple val(name), path(txt_files)
     output:

--- a/workflows/process/quality_genome_filter.nf
+++ b/workflows/process/quality_genome_filter.nf
@@ -1,6 +1,6 @@
 process quality_genome_filter {
     label 'ubuntu'
-    publishDir "${params.output}/${params.genomedir}/${name}/", mode: 'copy', pattern: "error_report_*.txt"
+    publishDir { "${params.output}/${params.genomedir}/${name}/" }, mode: 'copy', pattern: "error_report_*.txt"
   input:
     tuple val(name), path(fasta)
   output:

--- a/workflows/process/rki_report.nf
+++ b/workflows/process/rki_report.nf
@@ -1,7 +1,7 @@
 process rki_report {
     label "ubuntu"
     publishDir "${params.output}/${params.rkidir}/valid", mode: 'copy', pattern: "rki_valid_report.csv"
-    publishDir "${params.output}/${params.rkidir}", mode: 'copy', pattern: "${readme}"
+    publishDir "${params.output}/${params.rkidir}", mode: 'copy', pattern: { "${readme}" }
     input:
         path(president_data)
         path(readme)
@@ -27,7 +27,7 @@ process rki_report {
 process rki_report_extended {
     label "ubuntu"
     publishDir "${params.output}/${params.rkidir}/valid", mode: 'copy', pattern: "rki_valid_report.csv"
-    publishDir "${params.output}/${params.rkidir}", mode: 'copy', pattern: "${readme}"
+    publishDir "${params.output}/${params.rkidir}", mode: 'copy', pattern: { "${readme}" }
     input:
         path(president_data)
         path(readme)


### PR DESCRIPTION
With Nextflow version 26.04, the strict syntax is further enforced.
Applied a fix to all processes/modules (see below). Additionally, introduced "USER" as new
params.variable in the nextflow.config to use it in workflow profiles.

Fix-description:
In consequence, a process only knows about variables once the input block is introduced.
This results in a problem with publishDir, which typically uses variables such as ${name} to describe paths and patterns.
E.g:
```
process ShowError{
    publishDir "${params.output}/path/to/${name}", mode: 'copy', pattern: "${name}"
    
    input:
        tuple val(name), path(file)
    ...
}
```

A simple fix is to put the publishDir-strings with yet-undefined variables in closures (curly brackets "{}") so they are interpreted at runtime:
```
process ShowError{
    publishDir { "${params.output}/path/to/${name}" }, mode: 'copy', pattern: { "${name}" }
    
    input:
        tuple val(name), path(file)
    ...
}
```